### PR TITLE
e019a: K=50 context window (extends e018c K=30)

### DIFF
--- a/docs/run-cards/e019a-context-k50.md
+++ b/docs/run-cards/e019a-context-k50.md
@@ -1,0 +1,35 @@
+---
+id: e019a
+created: 2026-03-16
+status: running
+type: architectural
+base_build: b001
+built_on: [e018c]
+source_paper: 2505.20171
+rollout_coherence: null
+prior_best_rc: 6.03
+---
+
+# Run Card: e019a-context-k50
+
+## Goal
+
+Test whether extending context from K=30 (500ms) to K=50 (833ms) continues the RC improvement trend. E018c showed K=10 to K=30 yielded a 3.7% gain (6.26 to 6.03). This tests the next point on the scaling curve.
+
+## What Changes
+
+Two config params from E018c: `context_len: 50`, `chunk_size: 50`. No code changes. Self-Forcing still enabled with ratio=4, unroll_length=3.
+
+## Target Metrics
+
+- **Primary:** rollout_coherence < 6.03 (beat E018c)
+- **Guard rails:** no regression in change_acc, action accuracy, or sf_loss
+
+## Cost Estimate
+
+- Expected runtime: ~12,000-13,000s (~200-220min) on A100 40GB. K=50 is ~67% longer sequences than K=30, so ~50-60% longer wall time accounting for overhead.
+- Estimated cost: ~$5-6
+
+## Risk
+
+Diminishing returns are likely as context grows. K=50 may exceed the useful temporal horizon for Melee state prediction, or the SSM may struggle to utilize the additional context effectively. If RC plateaus or regresses, that establishes the ceiling for this axis.

--- a/experiments/e019a-context-k50.yaml
+++ b/experiments/e019a-context-k50.yaml
@@ -1,0 +1,63 @@
+# E019a: Extended context window K=50 (833ms at 60fps)
+# Changes from E018c: context_len 30 → 50, chunk_size 30 → 50
+# Everything else identical including Self-Forcing.
+#
+# K=30 is 500ms — covers a full move sequence (E018c: RC 6.03).
+# K=50 is 833ms — nearly a full second of context.
+# Tests whether the SSM benefits continue scaling with longer context.
+
+data:
+  dataset_dir: null
+  max_games: null
+  stage_filter: 32
+  character_filter: [1, 2, 7, 18, 22]
+
+encoding:
+  state_age_as_embed: true
+  state_age_embed_vocab: 150
+  state_age_embed_dim: 8
+  state_flags: true
+  hitstun: true
+  ctrl_threshold_features: true
+  multi_position: true
+  focal_offset: 0
+  projectiles: false
+  press_events: false
+  lookahead: 0
+
+model:
+  arch: mamba2
+  context_len: 50       # was 30 — 833ms instead of 500ms
+  d_model: 384
+  d_state: 64
+  n_layers: 4
+  headdim: 64
+  dropout: 0.1
+  chunk_size: 50        # must equal context_len for SSD scan
+
+training:
+  lr: 0.0005
+  weight_decay: 0.00001
+  batch_size: 512
+  num_epochs: 1
+  train_split: 0.9
+  log_interval: 100
+
+self_forcing:
+  enabled: true
+  ratio: 4
+  unroll_length: 3
+
+loss_weights:
+  continuous: 1.0
+  velocity: 0.5
+  dynamics: 0.5
+  binary: 1.0
+  action: 2.0
+  jumps: 0.5
+  l_cancel: 0.3
+  hurtbox: 0.3
+  ground: 0.3
+  last_attack: 0.3
+
+save_dir: checkpoints/e019a-context-k50


### PR DESCRIPTION
## Summary
- Extend context window from K=30 to K=50 (833ms at 60fps)
- Config-only change: context_len and chunk_size
- Self-Forcing still enabled (20% SF, N=3, uniform)
- Follows proven architectural axis: K=10→K=30 improved RC by 3.7%

## Hypothesis
K=30 (500ms) covers one move sequence. K=50 (833ms) covers multi-move interactions. If the SSM benefits from more temporal context, RC should improve further.

## Director Review
APPROVED. "K=10→K=30 result was not a fluke — zero TF trade-offs. K=50 is the natural next step. If diminishing returns appear, we know where the ceiling is."

## Target
- RC < 6.03 (E018c baseline)
- Kill if RC ≥ 6.03

🤖 Generated with [Claude Code](https://claude.com/claude-code)