### PR TITLE
e021b: selective BPTT — continuous heads only at SF steps 2+ (N=4)

### DIFF
--- a/docs/run-cards/e021b-selective-bptt.md
+++ b/docs/run-cards/e021b-selective-bptt.md
@@ -1,0 +1,43 @@
+---
+id: e021b
+created: 2026-03-16
+status: running
+type: training-regime
+base_build: b001
+built_on: [e018c]
+source_paper: null
+rollout_coherence: null
+prior_best_rc: 6.03
+---
+
+# Run Card: e021b-selective-bptt
+
+## Goal
+
+Test whether detaching categorical head gradients during SF steps 2+ improves rollout coherence. The 400-class action softmax produces large, noisy gradients that may destabilize the shared trunk during multi-step BPTT. By restricting autoregressive gradient flow to continuous/binary heads (smooth, low-variance signals), the trunk can learn better physics dynamics while categoricals still train on the teacher-forced step 0.
+
+Also tests N=4 unroll, which previously regressed at N=5 (e018b) and was cancelled at N=4 (e020c). Selective BPTT may unlock longer unrolls by reducing gradient noise.
+
+## What Changes
+
+Two changes from E018c:
+1. `self_forcing.selective_bptt: true` — detach all categorical head predictions (`*_logits` except `binary_logits`) at SF steps >= 1
+2. `self_forcing.unroll_length: 4` — N=4 (was 3 in e018c)
+
+Code change in `training/trainer.py` `_self_forcing_step()`: after model forward pass, for steps >= 1 when `sf_selective_bptt` is enabled, detach all prediction keys except `continuous_delta`, `velocity_delta`, `dynamics_pred`, and `binary_logits`.
+
+## Data
+
+1.9K FD top-5, 1 epoch, bs=512. K=30 context. Identical to E018c except SF config.
+
+## Target Metrics
+
+| Metric | E018c (N=3, full BPTT) | Target | Kill threshold |
+|--------|------------------------|--------|---------------|
+| **rollout_coherence** | **6.03** | **< 6.03** | >= 6.10 |
+| sf_loss | 0.367 | Monitor | > 0.55 (degrading) |
+| pos_mae | 0.824 | <= 0.824 | > 0.90 |
+
+## Cost Estimate
+
+~$5-6 Scout. Slightly longer per SF batch (4 forward passes vs 3), partially offset by fewer backward-pass parameters per step.

--- a/experiments/e021b-selective-bptt.yaml
+++ b/experiments/e021b-selective-bptt.yaml
@@ -1,0 +1,66 @@
+# E021b: Selective BPTT — detach categorical heads during SF steps 2+
+# From E018c baseline. Categorical heads (action, jumps, l_cancel, etc.) are
+# detached for SF steps >= 1, so only continuous/binary heads backprop through
+# the autoregressive chain. Categorical heads still get full gradient at step 0.
+#
+# Hypothesis: 400-class action softmax gradients dominate and destabilize the
+# trunk during multi-step BPTT. Detaching them lets the trunk learn smooth
+# physics dynamics from continuous heads, while categoricals still train on
+# step 0 (teacher-forced). Unroll N=4 (was too aggressive without selective BPTT).
+
+data:
+  dataset_dir: null
+  max_games: null
+  stage_filter: 32
+  character_filter: [1, 2, 7, 18, 22]
+
+encoding:
+  state_age_as_embed: true
+  state_age_embed_vocab: 150
+  state_age_embed_dim: 8
+  state_flags: true
+  hitstun: true
+  ctrl_threshold_features: true
+  multi_position: true
+  focal_offset: 0
+  projectiles: false
+  press_events: false
+  lookahead: 0
+
+model:
+  arch: mamba2
+  context_len: 30
+  d_model: 384
+  d_state: 64
+  n_layers: 4
+  headdim: 64
+  dropout: 0.1
+  chunk_size: 30
+
+training:
+  lr: 0.0005
+  weight_decay: 0.00001
+  batch_size: 512
+  num_epochs: 1
+  train_split: 0.9
+  log_interval: 100
+
+self_forcing:
+  enabled: true
+  ratio: 4
+  unroll_length: 4        # N=4 (unlocked by selective BPTT)
+  selective_bptt: true    # Detach categorical heads for SF steps >= 1
+
+loss_weights:
+  continuous: 1.0
+  velocity: 0.5
+  dynamics: 0.5
+  binary: 1.0
+  action: 2.0
+  jumps: 0.5
+  l_cancel: 0.3
+  hurtbox: 0.3
+  ground: 0.3
+  last_attack: 0.3
+
+save_dir: checkpoints/e021b-selective-bptt

--- a/scripts/modal_train.py
+++ b/scripts/modal_train.py
@@ -268,6 +268,7 @@ def train(
         sf_ratio=sf_cfg.get("ratio", 4),
         sf_unroll_length=sf_cfg.get("unroll_length", 3),
         sf_horizon_weights=sf_cfg.get("horizon_weights", False),
+        sf_selective_bptt=sf_cfg.get("selective_bptt", False),
     )
 
     history = trainer.train()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -322,6 +322,7 @@ def main():
         sf_ratio=sf_cfg.get("ratio", 4),
         sf_unroll_length=sf_cfg.get("unroll_length", 3),
         sf_horizon_weights=sf_cfg.get("horizon_weights", False),
+        sf_selective_bptt=sf_cfg.get("selective_bptt", False),
     )
 
     # Train

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -54,6 +54,7 @@ class Trainer:
         sf_ratio: int = 4,
         sf_unroll_length: int = 3,
         sf_horizon_weights: bool = False,
+        sf_selective_bptt: bool = False,
     ):
         if device is None:
             if torch.backends.mps.is_available():
@@ -138,6 +139,7 @@ class Trainer:
         self._sf_ratio = sf_ratio
         self._sf_unroll = sf_unroll_length
         self._sf_horizon_weights = sf_horizon_weights
+        self._sf_selective_bptt = sf_selective_bptt
         self._sf_valid_starts = None
         if sf_enabled:
             if dataset is None:
@@ -154,8 +156,9 @@ class Trainer:
                         starts.append(t)
                 self._sf_valid_starts = np.array(starts, dtype=np.int64)
                 logger.info(
-                    "Self-Forcing: %d valid starts, ratio=1:%d, unroll=%d",
+                    "Self-Forcing: %d valid starts, ratio=1:%d, unroll=%d, selective_bptt=%s",
                     len(self._sf_valid_starts), sf_ratio, sf_unroll_length,
+                    sf_selective_bptt,
                 )
 
         # Shape preflight
@@ -316,6 +319,21 @@ class Trainer:
             ctrl_d = ctrl.to(self.device)
 
             preds = self.model(ctx_f, ctx_i, ctrl_d)
+
+            # Selective BPTT: for steps >= 1, detach categorical heads so
+            # only continuous/binary heads receive gradient through the
+            # autoregressive chain. Categorical heads (action_state etc.)
+            # still get teacher-forced gradient at step 0.
+            if self._sf_selective_bptt and step > 0:
+                _CONTINUOUS_KEYS = {
+                    'continuous_delta', 'velocity_delta',
+                    'dynamics_pred', 'binary_logits',
+                }
+                preds = {
+                    k: v if k in _CONTINUOUS_KEYS else v.detach()
+                    for k, v in preds.items()
+                }
+
             loss, metrics = self.metrics.compute_loss(
                 preds, float_tgt.to(self.device), int_tgt.to(self.device), ctx_i,
             )


### PR DESCRIPTION
## Summary
- Detach categorical head gradients at SF unroll steps 2+
- Keep continuous heads (position, velocity, dynamics, binary) live
- Use N=4 unroll (between working N=3 and failed N=5)
- Tests whether categorical gradient noise caused E018b's N=5 regression

## Director Review
APPROVED (moderate-high confidence). "Orthogonal to prior failures. Addresses E018b regression mechanism. Grounded in multi-task learning literature (gradient surgery)."

## Target
- RC < 6.03 (E018c baseline)
- Kill if RC >= 6.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)