### PR TITLE
e022a: Halve batch size to 256

### DIFF
--- a/docs/run-cards/e022a-bs256.md
+++ b/docs/run-cards/e022a-bs256.md
@@ -1,0 +1,48 @@
+---
+id: e022a
+created: 2026-03-19
+status: running
+type: hyperparameter
+base_build: b001
+built_on: [e018c]
+source_paper: null
+rollout_coherence: null
+prior_best_rc: 6.03
+---
+
+# Run Card: e022a-bs256
+
+## Goal
+
+Test whether halving batch size (512 to 256) improves rollout coherence via implicit regularization and doubled gradient updates per epoch. Karpathy's autoresearch identified smaller batch size as the single largest improvement for small-data regimes. With only 1.9K training games, 2x more gradient steps should improve generalization.
+
+## Mechanism
+
+Two complementary effects from halving batch size:
+
+1. **More gradient updates.** Same data, twice as many optimizer steps per epoch. On a 1.9K dataset, this means the model sees more diverse gradient signals per pass.
+2. **Implicit regularization.** Noisier gradient estimates from smaller batches act as a regularizer, discouraging sharp minima and favoring flatter loss landscapes that generalize better.
+
+LR is halved from 5e-4 to 2.5e-4 per the linear scaling rule (LR proportional to batch size), following standard practice from Goyal et al. (2017).
+
+## What Changes
+
+Two coupled config params from E018c (counts as one variable per linear scaling rule):
+
+- `batch_size: 256` (was 512)
+- `lr: 0.00025` (was 0.0005)
+
+No code changes. All other hyperparameters, model architecture, and Self-Forcing settings identical to E018c.
+
+**Confound note:** LR=2.5e-4 is derived mechanically from the linear scaling rule (LR proportional to BS). The actual optimal LR at BS=256 may differ. This experiment tests the batch_size+LR pair together, not batch_size in isolation. If results are promising, a follow-up LR sweep at BS=256 could disentangle the contributions.
+
+## Target Metrics
+
+- **RC < 6.00** (improve on E018c's 6.03). RC prediction: improve below 6.00.
+- **Kill threshold: RC >= 6.10** (discard if regression)
+
+## Compute
+
+- GPU: A100 40GB (locked per Director condition)
+- Estimated runtime: ~3hr (2x gradient steps, but smaller batch = similar GPU utilization)
+- Estimated cost: ~$5-6 Scout

--- a/experiments/e022a-bs256.yaml
+++ b/experiments/e022a-bs256.yaml
@@ -1,0 +1,63 @@
+# E022a: Halve batch size 512 -> 256
+# Changes from E018c: batch_size 512 -> 256, lr 5e-4 -> 2.5e-4
+# LR scaled linearly with batch size (linear scaling rule).
+# Everything else identical to E018c.
+#
+# Hypothesis: smaller batches = 2x gradient updates on 1.9K dataset,
+# plus implicit regularization from noisier gradients.
+
+data:
+  dataset_dir: null
+  max_games: null
+  stage_filter: 32
+  character_filter: [1, 2, 7, 18, 22]
+
+encoding:
+  state_age_as_embed: true
+  state_age_embed_vocab: 150
+  state_age_embed_dim: 8
+  state_flags: true
+  hitstun: true
+  ctrl_threshold_features: true
+  multi_position: true
+  focal_offset: 0
+  projectiles: false
+  press_events: false
+  lookahead: 0
+
+model:
+  arch: mamba2
+  context_len: 30       # was 10 — 500ms instead of 167ms
+  d_model: 384
+  d_state: 64
+  n_layers: 4
+  headdim: 64
+  dropout: 0.1
+  chunk_size: 15        # must divide context_len; use < context_len for SSD benefit
+
+training:
+  lr: 0.00025           # halved from 0.0005 (linear scaling rule: LR ∝ BS)
+  weight_decay: 0.00001
+  batch_size: 256       # halved from 512
+  num_epochs: 1
+  train_split: 0.9
+  log_interval: 100
+
+self_forcing:
+  enabled: true
+  ratio: 4
+  unroll_length: 3
+
+loss_weights:
+  continuous: 1.0
+  velocity: 0.5
+  dynamics: 0.5
+  binary: 1.0
+  action: 2.0
+  jumps: 0.5
+  l_cancel: 0.3
+  hurtbox: 0.3
+  ground: 0.3
+  last_attack: 0.3
+
+save_dir: checkpoints/e022a-bs256


### PR DESCRIPTION
## Summary
- Halve batch size 512→256, LR 5e-4→2.5e-4 (linear scaling rule)
- Hypothesis: implicit regularization + 2× gradient updates → better AR quality
- Karpathy's autoresearch found this was single-largest improvement
- Never tested in this project — bs=512 inherited from nojohns

## Director Review
REVISE→APPROVED. Conditions met: GPU locked to A100, LR=2.5e-4 documented as confound, RC target tightened to < 6.00.

## Cost
~$5-6 Scout (A100 40GB, ~3hr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)