### PR TITLE
e023c: d_model=512 (width efficient frontier)

### DIFF
--- a/docs/run-cards/e023c-dmodel512.md
+++ b/docs/run-cards/e023c-dmodel512.md
@@ -1,0 +1,75 @@
+---
+id: e023c
+created: 2026-03-20
+status: running
+type: architectural
+base_build: b001
+built_on: [e023b]
+source_paper: null
+rollout_coherence: null
+prior_best_rc: 5.775
+---
+
+# Run Card: e023c-dmodel512
+
+## Goal
+
+Phase 2 — find the efficient frontier between d_model=384 (RC 6.026) and d_model=768 (RC 5.775). The width axis is monotonic so far (192 < 384 < 768). d_model=512 is the midpoint: does it capture most of 768's gain at ~46% the param cost?
+
+This matters for deployment. Fewer params = smaller onchain weight accounts, faster upload, lower CU per frame. If 512 gets within ~1% of 768, it's the better production choice.
+
+## Context
+
+| Config | d_model | d_inner | num_heads | Params | RC | Notes |
+|--------|---------|---------|-----------|--------|----|-------|
+| E023a | 192 | 384 | 6 | ~1.3M | 6.065 | Underfitting |
+| E018c | 384 | 768 | 12 | 4,275,810 | 6.026 | Former best |
+| **E023c** | **512** | **1024** | **16** | **7,276,306** | **?** | **This experiment** |
+| E023b | 768 | 1536 | 24 | 15,648,882 | 5.775 | Current best |
+
+7.3M params at ~1.9K training games = ~3,800 params/game. Between E018c (2,250) and E023b (8,200). Moderate overfitting risk.
+
+## What Changes
+
+One config change from E023b: `d_model: 512` (was 768).
+
+- d_inner = 2 * 512 = 1024
+- num_heads = 1024 / 64 = 16 (headdim=64 unchanged)
+- All other hyperparameters identical
+
+## Target Metrics
+
+- **Keep:** RC < 5.775 (improvement over E023b) or RC within ~2% of 5.775 with clear efficiency advantage
+- **Kill:** RC > 6.03 (regression past E018c baseline)
+
+## Model
+
+| Param | E018c | E023c | E023b |
+|-------|-------|-------|-------|
+| d_model | 384 | **512** | 768 |
+| d_state | 64 | 64 | 64 |
+| n_layers | 4 | 4 | 4 |
+| headdim | 64 | 64 | 64 |
+| d_inner | 768 | 1024 | 1536 |
+| num_heads | 12 | 16 | 24 |
+| Total params | 4,275,810 | **7,276,306** | 15,648,882 |
+
+## Training
+
+Identical to E023b:
+- lr: 0.0005, weight_decay: 1e-5, batch_size: 512, 1 epoch
+- Self-Forcing: ratio=4 (20%), unroll_length=3
+- context_len=30, chunk_size=15
+
+## Cost
+
+~$6 Scout tier (A100 40GB). 7.3M params is between E018c (4.3M, ~$4) and E023b (15.6M, ~$8.70). Expect ~2.5hr runtime.
+
+## Confounds
+
+- 3,800 params/game is moderate. Less overfitting risk than E023b (8,200) but watch val loss vs train loss.
+- If RC lands between 384 and 768, the width-RC curve shape tells us whether returns are diminishing (concave) or accelerating (convex). This informs whether to test d_model=1024 next.
+
+## Results
+
+_Pending._

--- a/experiments/e023c-dmodel512.yaml
+++ b/experiments/e023c-dmodel512.yaml
@@ -1,0 +1,63 @@
+# E023c: Intermediate d_model — 384 → 512 → 768
+# Changes from E023b: d_model 768 → 512
+# Everything else identical.
+#
+# Phase 2 architecture grid — find efficient frontier.
+# d_inner = 2*d_model = 1024, num_heads = d_inner/headdim = 1024/64 = 16.
+# Tests whether d_model=512 captures most of 768's gain at lower param cost.
+
+data:
+  dataset_dir: null
+  max_games: null
+  stage_filter: 32
+  character_filter: [1, 2, 7, 18, 22]
+
+encoding:
+  state_age_as_embed: true
+  state_age_embed_vocab: 150
+  state_age_embed_dim: 8
+  state_flags: true
+  hitstun: true
+  ctrl_threshold_features: true
+  multi_position: true
+  focal_offset: 0
+  projectiles: false
+  press_events: false
+  lookahead: 0
+
+model:
+  arch: mamba2
+  context_len: 30       # was 10 — 500ms instead of 167ms
+  d_model: 512
+  d_state: 64
+  n_layers: 4
+  headdim: 64
+  dropout: 0.1
+  chunk_size: 15        # must divide context_len; use < context_len for SSD benefit
+
+training:
+  lr: 0.0005
+  weight_decay: 0.00001
+  batch_size: 512
+  num_epochs: 1
+  train_split: 0.9
+  log_interval: 100
+
+self_forcing:
+  enabled: true
+  ratio: 4
+  unroll_length: 3
+
+loss_weights:
+  continuous: 1.0
+  velocity: 0.5
+  dynamics: 0.5
+  binary: 1.0
+  action: 2.0
+  jumps: 0.5
+  l_cancel: 0.3
+  hurtbox: 0.3
+  ground: 0.3
+  last_attack: 0.3
+
+save_dir: checkpoints/e023c-dmodel512


### PR DESCRIPTION
## Summary
- d_model=512 (7.3M params) — intermediate between 384 (4.3M, RC 6.026) and 768 (15.8M, RC 5.775)
- Phase 2: find the efficient frontier on width axis
- If 512 ≈ 768: we save 2× params for free. If 512 << 768: scaling law is steep.

## Cost
~$6 Scout (A100)