### PR TITLE
JEPA identity diagnostics + data flow docs

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -31,6 +31,36 @@ Rationale:
 
 Lineage pinned in the run card: **e028a** (JEPA on 2K) → **e028b** (v1-minimal encoding ablation on 2K) → **e028c** (data scaling to 7.7K with whatever 2K regime proved best).
 
+### Identity preservation: structural concern, diagnostic suite shipped
+
+Late addition to the review after walking through the encoder data flow in detail (full trace in `docs/jepa-data-flow.md`). The encoder concatenates P0 and P1 features into dedicated slots (no pooling, so the exact CLIP bag-of-words failure doesn't apply), but the trunk MLP is free to learn swap-symmetric features. And unlike Mamba2 — whose per-player prediction heads force distinct P0/P1 representation at every gradient step — **JEPA's loss does not explicitly penalize player identity collapse**. SIGReg regularizes the latent distribution; MSE measures predictor self-consistency; neither cares who is who. `pred_loss` indirectly requires identity preservation only to the extent that specific next-frame predictions are sensitive to it. Dittos are where this breaks first.
+
+This is now Key Risk #1 in the run card. Mamba2 is probably fine here (loss shape protects it) but it's "probably" not "verified" — pulling that into a follow-up task **after e028a launches**, not before, to keep context focused.
+
+**Diagnostic suite shipped as pure additions** in this PR (non-conflicting with Scav's in-flight blocking-fix work):
+
+- `training/jepa_diagnostics.py` — `swap_test`, `run_linear_probes`, `temporal_straightness`, and a `run_diagnostic_suite` one-shot. All closed-form, GPU-resident, no sklearn dependency. Smoke-tested end-to-end via the script below.
+- `scripts/run_jepa_diagnostics.py` — CLI that loads a checkpoint, pulls a held-out batch from the encoded .pt (or uses synthetic smoke data), runs the suite, prints grouped metrics + a plain-English interpretation, optionally writes JSON.
+- `docs/jepa-data-flow.md` — full step-by-step trace of how P0 and P1 reach the latent, including where identity can fail and why JEPA is structurally weaker than Mamba2 on this axis. This is the reference for anyone touching the encoder from here on.
+
+**How to wire into training (for Scav when ready — not done in this PR to avoid collision):**
+
+1. In `JEPATrainer.__init__`, after the val loader is built, pull a fixed diagnostic batch once (first ~256 val samples via `val_dataset.get_batch(np.arange(256))`) and stash it on `self.diagnostic_batch` as GPU tensors. This batch is used identically every epoch so numbers are comparable across epochs.
+2. At the end of `train()`'s per-epoch block (after `_val_epoch()` and before checkpointing), call:
+   ```python
+   from training.jepa_diagnostics import run_diagnostic_suite
+   if self.diagnostic_batch is not None:
+       diag = run_diagnostic_suite(self.model, *self.diagnostic_batch)
+       combined.update(diag)
+       if wandb and wandb.run:
+           wandb.log(diag)
+   ```
+3. `run_diagnostic_suite` handles `model.eval()` / restore internally, so this is safe to call from anywhere.
+
+**Pre-registered architectural fix**: if e028a's diagnostics show `swap.ditto_cosine_sim > 0.9` or any per-player probe R² < 0.3, the next experiment is **e028-identity-fix**: per-player shared-weight sub-encoder + cross-attention fusion (AlphaZero pattern). Don't debate the architecture after observing the failure — ship the ready replacement. See run card Lineage plan.
+
+**Reporting policy (not a gate, yet)**: swap similarity (mean + ditto) and per-player probe R² are required reported numbers in every JEPA run card's closeout, alongside RC. Not a kept/discarded gate — we need 5–10 runs' worth of observed values before setting a principled threshold. Until then: report, track, flag anomalies.
+
 ### Epistemic changes — shorter horizons, cheaper loop
 
 **Shorten rollout coherence to K=5 and K=10, report both.** K=20 is hard to discriminate at 60fps fighting game chaos — the last few kept experiments are at the noise floor (E027c 4.939 → E028a 4.798 is ~2.9% where the trajectory is already chaos-dominated). RC@5 is a pure local-dynamics test (does the model understand the immediate transition at all?) and is where architecture differences actually live. RC@10 gives near-horizon coherence without drowning in divergence. This is also a compute win — shorter AR unroll means per-epoch eval is affordable, which unlocks the instrumentation below. This shortening should eventually apply project-wide; first use is e028a.

--- a/docs/jepa-data-flow.md
+++ b/docs/jepa-data-flow.md
@@ -1,0 +1,222 @@
+# How P0 and P1 Reach the JEPA Latent
+
+A trace of the data flow from raw game state through the JEPA encoder, with focus on **where player identity lives at each step** and why it matters.
+
+## Why this page exists
+
+CLIP and similar contrastive models have a well-known "bag-of-words" failure mode: "put yellow cup on pink cup" and "put pink cup on yellow cup" pool to nearly the same vector because the attention-then-pool pipeline discards word order. The analogous question for our two-player world model is: **when JEPA encodes a frame, can it tell P0 from P1, or do their features get averaged into a single "game situation" vector that loses identity?**
+
+Our architecture doesn't have CLIP's *exact* pathology — we concat, we don't pool — but it has a related one: the trunk MLP is free to learn swap-symmetric features even if the slots are dedicated. This page is the reference for understanding what the encoder actually does with P0/P1 features, so that the diagnostic instrumentation (`training/jepa_diagnostics.py`) and any future architectural changes are grounded in the real data flow.
+
+## Input layout (what the dataset hands to the encoder)
+
+A single frame is three tensors:
+
+| Tensor | Shape | Contents |
+|--------|-------|----------|
+| `float_frames` | `(B, T, F)` where `F = 2 * float_per_player` | Continuous + binary + controller features for both players, concatenated |
+| `int_frames` | `(B, T, I)` where `I = 2 * int_per_player + 1` | Categorical indices for both players, plus stage |
+| `ctrl_inputs` | `(B, T, C)` | Controller features (extracted from float_frames, re-packed for predictor conditioning) |
+
+### `float_frames` — the dedicated-slot layout
+
+Everything is **concatenation by position**. For `float_per_player = fp`:
+
+```
+float_frames[..., 0      : fp    ]  ← P0's features
+float_frames[..., fp     : 2*fp  ]  ← P1's features
+```
+
+Inside each player's `fp` slots, the order is fixed by `EncodingConfig`:
+
+```
+[percent, x, y, shield,                                     ← core_continuous (4)
+ speed_air_x, speed_y, speed_ground_x, speed_attack_x, speed_attack_y,  ← velocity (5)
+ hitlag, stocks, (state_age), (hitstun),                    ← dynamics (2-4)
+ combo_count,                                                ← combat_continuous (1)
+ (projectile features),                                      ← optional
+ facing, invulnerable, on_ground, (state_flag bits×40),     ← binary (3 or 43)
+ stick_x, stick_y, cstick_x, cstick_y, shoulder,            ← analog controller (5)
+ a, b, x, y, z, l, r, start]                                ← button controller (8)
+```
+
+**Key: P0's `x` lives at index `1`. P1's `x` lives at index `fp + 1`.** They are never in the same slot. There is no averaging operation anywhere in the pipeline that would combine them before the trunk MLP sees them.
+
+### `int_frames` — categoricals
+
+For `int_per_player = ipp` (7 or 8 depending on `state_age_as_embed`):
+
+```
+int_frames[..., 0        : ipp    ]  ← P0's categoricals
+int_frames[..., ipp      : 2*ipp  ]  ← P1's categoricals
+int_frames[..., 2*ipp    : 2*ipp+1]  ← stage (shared)
+```
+
+Inside each player's block, the fixed order is:
+
+```
+[action, jumps, character, l_cancel, hurtbox, ground, last_attack, (state_age)]
+```
+
+So **P0's character ID is `int_frames[..., 2]`, P1's character ID is `int_frames[..., ipp + 2]`.** Dittos (same character on both ports) are detectable by comparing these two columns.
+
+### `ctrl_inputs` — what the predictor sees for AdaLN conditioning
+
+Built by `JEPAFrameDataset._extract_ctrl` from the float_frames. For `ctrl_threshold_features=true` and `press_events=false`, `lookahead=0`:
+
+```
+ctrl_inputs = cat([
+    p0_ctrl,          # 13 dims  (analog + buttons)
+    p1_ctrl,          # 13 dims
+    p0_analog_thresh, # 5  dims  (|stick| > 0.3 binarization)
+    p1_analog_thresh, # 5  dims
+])                    # 36 dims total
+```
+
+Same story: positional slots, P0 and P1 never share a dim.
+
+## Step-by-step through `GameStateEncoder.forward`
+
+`models/jepa/encoder.py:75-115`. The encoder receives `(float_frames, int_frames)` and produces `(B, T, embed_dim)` latents. I'll trace one frame's worth.
+
+```python
+flat_float = float_frames.reshape(B*T, F)
+flat_int   = int_frames.reshape(B*T, I)
+```
+
+So we're working on `(B*T, F)` and `(B*T, I)`. Every frame from every batch is now a row.
+
+### 1. Categorical embedding lookups
+
+```python
+parts = [flat_float]
+
+for offset in [0, ipp]:                     # ← P0 then P1
+    parts.append(self.action_embed(flat_int[:, offset + 0]))       # action (32D)
+    parts.append(self.jumps_embed(flat_int[:, offset + 1]))        # jumps (4D)
+    parts.append(self.character_embed(flat_int[:, offset + 2]))    # character (8D)
+    parts.append(self.l_cancel_embed(flat_int[:, offset + 3]))     # l_cancel (2D)
+    parts.append(self.hurtbox_embed(flat_int[:, offset + 4]))      # hurtbox (2D)
+    parts.append(self.ground_embed(flat_int[:, offset + 5]))       # ground (4D)
+    parts.append(self.last_attack_embed(flat_int[:, offset + 6]))  # last_attack (8D)
+    if self.cfg.state_age_as_embed:
+        parts.append(self.state_age_embed(flat_int[:, offset + 7]))# state_age (8D)
+
+parts.append(self.stage_embed(flat_int[:, -1]))                    # stage (4D)
+```
+
+Each `nn.Embedding.lookup` is an indexed fetch. `self.action_embed` is a single `nn.Embedding(400, 32)` whose weights are **shared between P0 and P1** — the model learns one action-embedding table and queries it twice, once for P0's action, once for P1's action. The two results land in **different `parts` entries**, which will become **different slot ranges** in the concatenated vector.
+
+This is a deliberate weight-sharing choice: the meaning of action state 47 (say, "falling") is the same regardless of which player is in it. Shared-weight categorical embeddings give the right inductive bias without hurting identity — identity is preserved by *position* in the output concat, not by *embedding weights*.
+
+### 2. The big concatenation
+
+```python
+x = torch.cat(parts, dim=-1)   # (B*T, total_input_dim)
+```
+
+This is the critical structural move. `parts` is ordered:
+
+```
+[flat_float,                              ← 2 * float_per_player dims (P0 floats || P1 floats)
+ P0_action, P0_jumps, ..., P0_state_age,  ← P0 categorical embeddings
+ P1_action, P1_jumps, ..., P1_state_age,  ← P1 categorical embeddings
+ stage]                                    ← shared
+```
+
+After the cat, `x` has shape `(B*T, total_input_dim)` where `total_input_dim ≈ 278` for the b002 encoding. **Each element of this vector has a fixed, dedicated meaning.** P0's action-embedding dim 5 is always at the same index, and it is never the same index as P1's action-embedding dim 5.
+
+This is the key difference from CLIP: **there is no pooling here.** CLIP would take a sequence of tokens `[yellow, cup, on, pink, cup]`, run them through a transformer, and then mean-pool (or CLS-token) the result to a single vector — that pooling is where word order gets lost. Our encoder has no equivalent step. Every input feature keeps its identity through the concat.
+
+### 3. The trunk — where structural guarantees end
+
+```python
+x = self.trunk(x)   # Linear(278→512) → SiLU → Linear(512→512) → SiLU
+```
+
+**This is where the CLIP-adjacent failure mode can sneak in.** The first `nn.Linear` has a weight matrix of shape `(512, 278)`. Each output neuron is a learned linear combination of **all** input features, including both P0's and P1's features. A neuron whose weight happens to be large for P0's x-position and equally large for P1's x-position will produce a feature that's swap-symmetric: it doesn't matter whether you put player A on port 0 or port 1, this neuron fires the same.
+
+The trunk can learn this, and in some regimes it **will** learn this, because:
+
+- **Shortcut bias.** If the downstream loss can be minimized with features that are functions of "the game situation" rather than "which player is which," gradient descent will happily discover them. Half the parameters become redundant.
+- **Dittos give no asymmetry signal.** In a Fox-vs-Fox match, the character embeddings for P0 and P1 are identical (same input → same embedding → same contribution to the trunk's weighted sum). The only P0/P1 distinguishing signal is positional/kinematic — x, y, velocity, action state. If those happen to also land on swap-symmetric trunk neurons, identity collapses for dittos specifically.
+- **No loss term explicitly penalizes identity collapse.** SIGReg regularizes the *distribution* of encoder outputs to be Gaussian. MSE in latent space measures whether the predictor can match the encoder's output. Neither of these terms cares who is P0 and who is P1, as long as the encoder is self-consistent and the predictor can track it. This is structurally **weaker** than Mamba2's loss, which has per-player prediction heads that literally compute separate MSEs for P0's next position and P1's next position.
+
+The trunk *can* learn to preserve identity — nothing forces it into collapse, and the downstream `pred_loss` genuinely requires knowing which player did what in order to predict the next frame. But it doesn't have to, and whether it does is an empirical question we need to measure.
+
+### 4. The projector
+
+```python
+x = self.projector(x)   # Linear(512→2048) → SiLU → Linear(2048→192) → BatchNorm1d
+```
+
+Matches LeWM's projector pattern. `BatchNorm1d` at the end normalizes each of the 192 output features to zero-mean unit-variance across the batch. BN doesn't cause identity collapse directly (it operates per-dim), but it does mean the final latent lives on a well-scaled manifold that SIGReg can then pull toward isotropic Gaussian. The projector is 2 linear layers deep, so it preserves whatever identity-aware structure the trunk produces — it doesn't re-mix P0/P1.
+
+### 5. Reshape back
+
+```python
+return x.reshape(B, T, self.embed_dim)
+```
+
+One 192-dim vector per (batch, time). All of P0 and P1's combined state is compressed into this single vector.
+
+## How the predictor uses it — AdaLN action conditioning
+
+`models/jepa/predictor.py`. The predictor takes `(context_embs, ctrl_inputs)` and outputs next-frame latent predictions.
+
+- `context_embs`: `(B, H, D)` — the 192-dim latents for the `history_size=3` context frames.
+- `ctrl_inputs`: `(B, H, 36)` — per-frame controller features (P0 and P1 concatenated, as above).
+
+Inside:
+
+```python
+action_embs = self.action_encoder(ctrl_inputs)  # (B, H, 192)
+x = context_embs + self.pos_embed[:, :H, :]
+for block in self.blocks:
+    x = block(x, action_embs, causal_mask)
+```
+
+The `action_encoder` is a 2-layer MLP that maps the 36-dim controller vector to a 192-dim action embedding. **Same positional-slot story as the state encoder:** P0's 13 controller dims and P1's 13 controller dims live in dedicated slots, the MLP can learn to preserve or collapse identity. The action embedding then modulates AdaLN shift/scale/gate at each transformer block — it's multiplicatively mixed into the latent, not appended as a separate token.
+
+The predictor's self-attention operates on the sequence of frame latents (length 3). It doesn't re-mix P0/P1 at the attention level because each timestep is already a single combined-player latent. Attention lets the model aggregate *temporal* context, not player context.
+
+## Where identity can fail
+
+Given the above trace, there are three concrete places to watch:
+
+1. **Encoder trunk MLP** learns swap-symmetric features. The 278→512 linear layer finds that averaging is a useful shortcut. This is the most likely failure mode. Detected by **swap test** on encoder outputs — swap P0↔P1 in the raw inputs, re-encode, measure cosine similarity. Expected low (distinct), observed high means collapse.
+
+2. **Projector BN collapses informative variance.** Less likely but possible: BN's cross-batch normalization interacts badly with SIGReg's isotropy pressure and squashes identity dimensions. Detected by **per-player linear probes** — fit a linear model from latent → P0.x and another from latent → P1.x. Both should fit well. If one is noise, identity has collapsed.
+
+3. **Action encoder MLP** collapses P0/P1 controller symmetry. The 36→192 action encoder could average P0 and P1 controllers. This would break the predictor's ability to condition on "who pressed what." Detected by **ctrl swap test** — swap P0/P1 controller inputs (without swapping the frame inputs), feed to predictor, verify predictions differ. Not yet implemented as a separate diagnostic — covered indirectly by the state-swap test.
+
+## The Mamba2 comparison
+
+Mamba2 has the same concat layout but a **different loss shape** that protects it: 16 prediction heads compute per-player MSEs and classification losses for each field separately. Every gradient step says "predict P0's x *separately from* P1's x." This is a strong, direct incentive for the encoder and backbone to keep identities distinct. The loss literally cannot be minimized without per-player representation.
+
+JEPA has one latent MSE + SIGReg. Neither cares about per-player identity per se. The `pred_loss` term indirectly requires identity preservation (because you can't predict the next frame without knowing who is doing what), but only to the extent that the specific next-frame prediction is sensitive to the distinction. For large-scale motion prediction this is probably fine; for subtle relational events (who is in hitstun from whom) the signal is weak.
+
+**This means JEPA is structurally more at risk of identity collapse than Mamba2, specifically because its loss doesn't explicitly bind identity.** That's why the diagnostic suite exists, and why we pre-register an architectural mitigation (per-player shared-weight sub-encoder + cross-attention fusion, canonical from AlphaZero) as the fix-of-first-resort if the swap test fires.
+
+## Diagnostic hooks
+
+All three failure modes have corresponding cheap diagnostics in `training/jepa_diagnostics.py`:
+
+| Diagnostic | Detects | How |
+|------------|---------|-----|
+| `swap_test` | Encoder trunk collapse | Encode `(floats, ints)` and `swap_p0_p1(floats, ints)`, compute cosine similarity. Low = good. |
+| `linear_probe_r2` applied per-player | Projector / downstream collapse | Fit linear regression from latent → P0.x, latent → P1.x separately. Both should be >0.8. |
+| `relational_probe_r2` | Cross-player binding | Fit linear regression from latent → `(P0.x - P1.x)`. Should fit well if the model encodes relative position. |
+| `temporal_straightness` | Trajectory quality (emergent from LeWM) | Cosine similarity of consecutive latent velocity vectors. Should increase during training. |
+
+All are GPU-resident, closed-form, and run on a fixed held-out batch per epoch. No sklearn, no extra dependencies. See the diagnostics module and `scripts/run_jepa_diagnostics.py` for wiring.
+
+## Related files
+
+- `models/jepa/encoder.py` — the trace above
+- `models/jepa/predictor.py` — AdaLN action conditioning
+- `data/jepa_dataset.py` — `_extract_ctrl` packing
+- `models/encoding.py` — `EncodingConfig` field layout and dimension properties
+- `training/jepa_diagnostics.py` — the identity diagnostic suite
+- `scripts/run_jepa_diagnostics.py` — CLI to run diagnostics on a trained checkpoint
+- `research/sources/jepa-adaptation-notes.md` — Open Question #4 on two-player dynamics (now actively being instrumented)

--- a/docs/run-cards/e028a-jepa-baseline.md
+++ b/docs/run-cards/e028a-jepa-baseline.md
@@ -65,7 +65,9 @@ Everything. This is a different architecture with a different training objective
 - **e028a** (this card) — JEPA paradigm test on 2K, LeWM defaults, instrumented for the cliff. Answers "does JEPA work on structured data at our scale?"
 - **e028b** — v1-minimal encoding ablation on 2K. Drop `state_flags`, `ctrl_threshold_features`, `multi_position` — test whether the inherited b002 data contract helps or hurts JEPA.
 - **e028c** — data scaling on 7.7K with whatever 2K regime proved best. Structured comparison against e029a.
-- **e028d+** — LR/WD sweep, history_size lever, two-player embedding structure, multi-step prediction (after unblocking `num_preds==1` assert).
+- **e028d+** — LR/WD sweep, history_size lever, multi-step prediction (after unblocking `num_preds==1` assert).
+
+**Pre-registered architectural fix — e028-identity-fix**: if e028a's identity diagnostics fire (`swap.ditto_cosine_sim > 0.9` or any per-player probe R² < 0.3), **before** running any other e028 experiment, run `e028-identity-fix` with a per-player shared-weight sub-encoder + cross-attention fusion. Same-weight encoder applied independently to each player, output as two tokens with explicit player-ID positional embedding, 2 layers of self-attention over the two tokens, mean-pool or CLS readout. This is the canonical two-player symmetric architecture from AlphaZero — it processes P0 and P1 with the same weights (right inductive bias for permutation symmetry of character logic) but positional embeddings + attention preserve and model their interaction. Pre-registering the fix means we don't debate the architecture after observing the failure; we have a ready replacement.
 
 ## Model
 
@@ -103,10 +105,24 @@ We're explicitly not assuming either "no cliff" or "cliff exists." We're setting
 **Primary signals (per epoch):**
 - `pred_loss`, `sigreg_loss` — training dynamics
 - **RC@5, RC@10** — shortened from K=20. Fighting game state at 60fps is chaos-dominated past ~150ms; K=20 is below the noise floor for architecture discrimination. K=5 (83ms) is a pure local-dynamics test; K=10 (167ms) is near-horizon coherence. Both numbers logged, neither alone is the north star.
-- **Linear probe accuracy** on held-out games for `position`, `percent`, `action_state`. Cheap (~30 lines of code), held-out, interpretable. This is the go/no-go signal — a JEPA run that can't linearly decode position from its latent has not learned a usable representation no matter what `pred_loss` says.
-- **Temporal straightness** — cosine similarity of consecutive latent velocity vectors. LeWM calls this out as an emergent diagnostic; free to compute.
+- **Identity diagnostics suite** — see below. Ships in `training/jepa_diagnostics.py`.
+- **Temporal straightness** — cosine similarity of consecutive latent velocity vectors. LeWM calls this out as an emergent diagnostic; free to compute; included in the diagnostic suite.
 
 **Why shortened RC:** K=20 is hard to discriminate — recent Mamba2 kept experiments (E027c 4.939 → E028a 4.798) are at ~2.9% deltas at K=20 where the trajectory is already chaos-dominated. RC@5 is where architecture differences actually live. Shorter AR unroll also unlocks affordable per-epoch eval, which unlocks the instrument-don't-cap policy above. The broader project-wide RC shortening is a follow-up.
+
+### Identity diagnostics (swap test, per-player probes, relational probe)
+
+See `docs/jepa-data-flow.md` for the full trace of how P0 and P1 reach the latent and why this failure mode is structurally more likely under JEPA's loss than Mamba2's. In short: the encoder concatenates both players' features into a dedicated-slot input, but the trunk MLP is free to learn swap-symmetric features, and unlike Mamba2 the JEPA loss does not explicitly penalize player-identity collapse. We need to measure whether it actually stays identity-aware or silently collapses. All three diagnostics run on a fixed held-out batch, per epoch, from `training/jepa_diagnostics.py`:
+
+| Diagnostic | Detects | Healthy | Collapsed |
+|------------|---------|---------|-----------|
+| `swap_test.mean_cosine_sim` | Encoder trunk learns swap-symmetric features | < ~0.5 | > ~0.9 |
+| `swap_test.ditto_cosine_sim` | Same, on ditto matchups where character asymmetry is zero (sharpest signal) | < ~0.5 | > ~0.9 |
+| `per_player_probes[p0_x, p1_x]` R² | Projector loses one player's info while keeping the other | both > 0.8 | one < 0.3 or large asymmetry |
+| `per_player_probes[p0_percent, p1_percent]` R² | Same, for percent | both > 0.8 | — |
+| `relational_probes[rel_x, rel_y]` R² | Latent encodes cross-player binding, not just stacked per-player slots | > 0.8 | < 0.3 |
+
+**Reporting policy**: swap similarity (mean + ditto) and per-player probe R² are **required reported numbers** in every JEPA run card from e028a onward, alongside RC. They are **not** a kept/discarded gate yet — we need 5–10 experiments' worth of observed values before we can set a principled threshold. Until then: report, track, and flag any run where `swap.ditto_cosine_sim > 0.9` or any per-player probe has R² < 0.3 in the run card's closeout discussion.
 
 ## Success Criteria
 
@@ -119,12 +135,12 @@ This is exploratory — we're testing a paradigm, not tuning a hyperparameter. G
 
 ## Key Risks
 
-1. **50ms context.** history_size=3 at 60fps = 50ms. Mamba2 uses 500ms. LeWM's 3 at frameskip=5 is effectively 15 raw frames — we're literal 3, so 5x less effective context. If this fails, increasing history_size is the first lever.
-2. **Encoder capacity.** 2-layer MLP vs LeWM's 12-layer ViT. May bottleneck representation quality. No input normalization before the trunk — relative feature magnitudes drive early gradients.
-3. **Data contract inherited from b002 without re-justification.** `state_flags`, `ctrl_threshold_features`, `multi_position`, `state_age_as_embed`, stage/char filters all were chosen for Mamba2 per-field heads. JEPA has no per-field heads. Directly tested by follow-up **e028b: v1-minimal encoding ablation**.
-4. **LR/WD/bs are LeWM defaults, not tuned for our data.** b002 settled on 10x higher LR and 100x lower WD. Probable levers after first run.
-5. **SIGReg only constrains encoder distribution.** Predictor output has no direct anti-collapse protection — watch for mode collapse via constant predictor in the probe.
-6. **Two-player dynamics** inherited as "concat both players." Open question #4 in `jepa-adaptation-notes.md`. Flagged for e028c or later, not e028a.
+1. **Player identity collapse.** The encoder concatenates P0 and P1 features into dedicated slots but then runs them through a 2-layer MLP trunk, which is free to learn swap-symmetric features. Unlike Mamba2, JEPA's loss does not explicitly penalize losing P0/P1 identity — SIGReg regularizes the latent *distribution*, MSE measures self-consistency, neither cares who is who. This is structurally more at risk than Mamba2's per-player head loss. Dittos (Fox vs Fox etc.) are the sharpest test. Instrumented by the swap test, per-player probes, and relational probes (see Evaluation). Pre-registered fix: per-player shared-weight sub-encoder + cross-attention fusion (see Lineage plan). Full trace in `docs/jepa-data-flow.md`.
+2. **50ms context.** history_size=3 at 60fps = 50ms. Mamba2 uses 500ms. LeWM's 3 at frameskip=5 is effectively 15 raw frames — we're literal 3, so 5x less effective context. If this fails, increasing history_size is the first lever.
+3. **Encoder capacity.** 2-layer MLP vs LeWM's 12-layer ViT. May bottleneck representation quality. No input normalization before the trunk — relative feature magnitudes drive early gradients.
+4. **Data contract inherited from b002 without re-justification.** `state_flags`, `ctrl_threshold_features`, `multi_position`, `state_age_as_embed`, stage/char filters all were chosen for Mamba2 per-field heads. JEPA has no per-field heads. Directly tested by follow-up **e028b: v1-minimal encoding ablation**.
+5. **LR/WD/bs are LeWM defaults, not tuned for our data.** b002 settled on 10x higher LR and 100x lower WD. Probable levers after first run.
+6. **SIGReg only constrains encoder distribution.** Predictor output has no direct anti-collapse protection — watch for mode collapse via constant predictor in the probe.
 
 ## Known blocking fixes (pre-Modal)
 

--- a/scripts/run_jepa_diagnostics.py
+++ b/scripts/run_jepa_diagnostics.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Run the JEPA identity diagnostic suite on a trained checkpoint.
+
+Callable post-hoc against a saved JEPA checkpoint, independent of the training
+loop. Intended for two uses:
+
+    1. Validate a checkpoint after training without re-running the whole loop.
+    2. Smoke-test the diagnostic suite itself during development (tiny
+       synthetic data + freshly-initialized model).
+
+Usage:
+    # Against a real checkpoint + pre-encoded data
+    python -m scripts.run_jepa_diagnostics \\
+        --checkpoint checkpoints/e028a-jepa-baseline/best.pt \\
+        --encoded-file /data/encoded-e012-fd-top5.pt
+
+    # Smoke test with random weights + random inputs
+    python -m scripts.run_jepa_diagnostics --smoke
+
+See docs/jepa-data-flow.md for what the diagnostics measure and
+training/jepa_diagnostics.py for the implementations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from models.encoding import EncodingConfig
+from models.jepa.model import JEPAWorldModel
+from training.jepa_diagnostics import run_diagnostic_suite
+
+
+logger = logging.getLogger("jepa_diagnostics")
+
+
+def _load_checkpoint(path: str, device: torch.device) -> tuple[JEPAWorldModel, EncodingConfig]:
+    """Load a JEPAWorldModel checkpoint.
+
+    The checkpoint schema written by training/jepa_trainer.py:
+        {"model_state_dict", "encoding_config" (dict), "history_size",
+         "embed_dim", "arch"="jepa", ...}
+    """
+    logger.info("Loading checkpoint: %s", path)
+    ckpt = torch.load(path, map_location="cpu", weights_only=False)
+
+    if ckpt.get("arch") != "jepa":
+        raise ValueError(
+            f"Checkpoint arch is {ckpt.get('arch')!r}, expected 'jepa'. "
+            f"This script only handles JEPA checkpoints."
+        )
+
+    enc_cfg_dict = ckpt["encoding_config"]
+    enc_cfg = EncodingConfig(
+        **{k: v for k, v in enc_cfg_dict.items() if hasattr(EncodingConfig, k)}
+    )
+
+    model = JEPAWorldModel(
+        cfg=enc_cfg,
+        embed_dim=ckpt.get("embed_dim", 192),
+        history_size=ckpt.get("history_size", 3),
+    )
+    model.load_state_dict(ckpt["model_state_dict"])
+    model.to(device).eval()
+    return model, enc_cfg
+
+
+def _build_smoke_model(device: torch.device) -> tuple[JEPAWorldModel, EncodingConfig]:
+    """Build a tiny JEPAWorldModel with default EncodingConfig for smoke tests.
+
+    No checkpoint required. The model has random weights, so diagnostics
+    results are noise — this mode exists to verify the plumbing runs
+    without errors, not to measure anything meaningful.
+    """
+    enc_cfg = EncodingConfig(
+        state_flags=True,
+        hitstun=True,
+        ctrl_threshold_features=True,
+        multi_position=True,
+        state_age_as_embed=True,
+    )
+    model = JEPAWorldModel(cfg=enc_cfg, embed_dim=64, history_size=3).to(device).eval()
+    return model, enc_cfg
+
+
+def _build_smoke_batch(
+    cfg: EncodingConfig,
+    B: int = 32,
+    T: int = 4,
+    device: torch.device = torch.device("cpu"),
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build a synthetic batch matching the shapes the encoder expects."""
+    fp = cfg.float_per_player
+    ipp = cfg.int_per_player
+
+    float_frames = torch.randn(B, T, 2 * fp, device=device) * 0.3
+
+    # Int frames: indices must be within vocab bounds. Mix a few ditto rows
+    # in so the swap test has some dittos to bucket.
+    int_frames = torch.zeros(B, T, 2 * ipp + 1, dtype=torch.long, device=device)
+    for b in range(B):
+        for t in range(T):
+            p0_char = torch.randint(0, cfg.character_vocab, (1,)).item()
+            p1_char = p0_char if b % 4 == 0 else torch.randint(0, cfg.character_vocab, (1,)).item()
+            int_frames[b, t, 0] = torch.randint(0, cfg.action_vocab, (1,))
+            int_frames[b, t, 1] = torch.randint(0, cfg.jumps_vocab, (1,))
+            int_frames[b, t, 2] = p0_char
+            int_frames[b, t, 3] = torch.randint(0, cfg.l_cancel_vocab, (1,))
+            int_frames[b, t, 4] = torch.randint(0, cfg.hurtbox_vocab, (1,))
+            int_frames[b, t, 5] = torch.randint(0, cfg.ground_vocab, (1,))
+            int_frames[b, t, 6] = torch.randint(0, cfg.last_attack_vocab, (1,))
+            if cfg.state_age_as_embed:
+                int_frames[b, t, 7] = torch.randint(0, cfg.state_age_embed_vocab, (1,))
+            int_frames[b, t, ipp + 0] = torch.randint(0, cfg.action_vocab, (1,))
+            int_frames[b, t, ipp + 1] = torch.randint(0, cfg.jumps_vocab, (1,))
+            int_frames[b, t, ipp + 2] = p1_char
+            int_frames[b, t, ipp + 3] = torch.randint(0, cfg.l_cancel_vocab, (1,))
+            int_frames[b, t, ipp + 4] = torch.randint(0, cfg.hurtbox_vocab, (1,))
+            int_frames[b, t, ipp + 5] = torch.randint(0, cfg.ground_vocab, (1,))
+            int_frames[b, t, ipp + 6] = torch.randint(0, cfg.last_attack_vocab, (1,))
+            if cfg.state_age_as_embed:
+                int_frames[b, t, ipp + 7] = torch.randint(0, cfg.state_age_embed_vocab, (1,))
+            int_frames[b, t, -1] = 32  # stage = FD
+
+    ctrl_inputs = torch.randn(B, T, cfg.ctrl_conditioning_dim, device=device) * 0.3
+    return float_frames, int_frames, ctrl_inputs
+
+
+def _build_batch_from_encoded(
+    encoded_file: str,
+    cfg: EncodingConfig,
+    history_size: int,
+    n_samples: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pull a diagnostic batch from a pre-encoded .pt dataset.
+
+    Matches the loading pattern in scripts/modal_train.py (reconstruct
+    MeleeDataset directly from the saved tensors). Uses JEPAFrameDataset
+    to produce (history_size + 1)-length subsequences.
+    """
+    from data.dataset import MeleeDataset
+    from data.jepa_dataset import JEPAFrameDataset
+
+    logger.info("Loading encoded data from %s", encoded_file)
+    payload = torch.load(encoded_file, map_location="cpu", weights_only=False)
+
+    dataset = MeleeDataset.__new__(MeleeDataset)
+    dataset.cfg = cfg
+    dataset.floats = payload["floats"]
+    dataset.ints = payload["ints"]
+    game_offsets = payload["game_offsets"]
+    if isinstance(game_offsets, torch.Tensor):
+        game_offsets = game_offsets.clone().numpy()
+    dataset.game_offsets = game_offsets
+    dataset.num_games = len(dataset.game_offsets) - 1
+    dataset.total_frames = int(dataset.game_offsets[-1])
+    dataset.game_lengths = [
+        int(dataset.game_offsets[i + 1] - dataset.game_offsets[i])
+        for i in range(dataset.num_games)
+    ]
+    logger.info("Dataset: %d games, %d frames", dataset.num_games, dataset.total_frames)
+
+    # Use the last 10% of games as the diagnostic pool (held out from training)
+    split_idx = max(1, int(dataset.num_games * 0.9))
+    jepa_ds = JEPAFrameDataset(
+        dataset,
+        range(split_idx, dataset.num_games),
+        history_size=history_size,
+        num_preds=1,
+    )
+
+    # Pull a fixed contiguous slice of the valid_indices for reproducibility
+    indices = np.arange(min(n_samples, len(jepa_ds)))
+    float_frames, int_frames, ctrl_inputs = jepa_ds.get_batch(indices)
+    return (
+        float_frames.to(device),
+        int_frames.to(device),
+        ctrl_inputs.to(device),
+    )
+
+
+def _format_metrics(metrics: dict[str, float]) -> str:
+    """Pretty-print diagnostic metrics grouped by section."""
+    groups: dict[str, list[tuple[str, float]]] = {}
+    for k, v in metrics.items():
+        section = k.split("/", 1)[0] if "/" in k else "misc"
+        groups.setdefault(section, []).append((k, v))
+
+    lines = []
+    for section in sorted(groups):
+        lines.append(f"\n[{section}]")
+        for k, v in sorted(groups[section]):
+            short = k.split("/", 1)[1] if "/" in k else k
+            if np_isnan(v):
+                lines.append(f"  {short:<28s}  nan")
+            else:
+                lines.append(f"  {short:<28s}  {v:.4f}")
+    return "\n".join(lines)
+
+
+def np_isnan(x: float) -> bool:
+    return x != x
+
+
+def _interpret(metrics: dict[str, float]) -> str:
+    """Short human-readable interpretation of the diagnostic results."""
+    lines = []
+
+    mean_swap = metrics.get("swap/mean_cosine_sim", float("nan"))
+    ditto_swap = metrics.get("swap/ditto_cosine_sim", float("nan"))
+
+    lines.append("# Interpretation")
+    lines.append("")
+
+    if np_isnan(mean_swap):
+        lines.append("- Swap test: no data")
+    elif mean_swap < 0.5:
+        lines.append(f"- Swap test: HEALTHY (mean cos sim {mean_swap:.3f} < 0.5)")
+    elif mean_swap < 0.9:
+        lines.append(f"- Swap test: WEAK (mean cos sim {mean_swap:.3f}, watch ditto)")
+    else:
+        lines.append(
+            f"- Swap test: COLLAPSED (mean cos sim {mean_swap:.3f} > 0.9) — "
+            f"encoder has lost P0/P1 identity"
+        )
+
+    if not np_isnan(ditto_swap):
+        if ditto_swap > 0.9:
+            lines.append(
+                f"- Ditto swap: COLLAPSED ({ditto_swap:.3f}) — in same-char matchups "
+                f"the encoder cannot distinguish players at all"
+            )
+        else:
+            lines.append(f"- Ditto swap: {ditto_swap:.3f}")
+
+    # Probes
+    probe_keys = [k for k in metrics if k.startswith("probe/") and k.endswith("_r2")]
+    if probe_keys:
+        p0_x = metrics.get("probe/p0_x_r2", float("nan"))
+        p1_x = metrics.get("probe/p1_x_r2", float("nan"))
+        rel_x = metrics.get("probe/rel_x_r2", float("nan"))
+        if not (np_isnan(p0_x) or np_isnan(p1_x)):
+            if p0_x > 0.8 and p1_x > 0.8:
+                lines.append(f"- Per-player x probes: HEALTHY (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f})")
+            elif abs(p0_x - p1_x) > 0.2:
+                lines.append(
+                    f"- Per-player x probes: ASYMMETRIC (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f}) — "
+                    f"one player is decodable, the other is not"
+                )
+            else:
+                lines.append(f"- Per-player x probes: WEAK (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f})")
+        if not np_isnan(rel_x):
+            if rel_x > 0.8:
+                lines.append(f"- Relational rel_x probe: HEALTHY (R²={rel_x:.3f}) — cross-player binding present")
+            else:
+                lines.append(f"- Relational rel_x probe: WEAK (R²={rel_x:.3f}) — cross-player binding missing")
+
+    straight = metrics.get("emergent/straightness", float("nan"))
+    if not np_isnan(straight):
+        lines.append(f"- Temporal straightness: {straight:.3f} (should INCREASE over training epochs)")
+
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run JEPA identity diagnostics")
+    parser.add_argument("--checkpoint", default=None, help="Path to JEPA checkpoint")
+    parser.add_argument("--encoded-file", default=None, help="Path to pre-encoded .pt dataset")
+    parser.add_argument("--smoke", action="store_true", help="Smoke test with random model/data")
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--device", default=None)
+    parser.add_argument("--json-out", default=None, help="Write metrics to JSON file")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if args.device:
+        device = torch.device(args.device)
+    elif torch.cuda.is_available():
+        device = torch.device("cuda")
+    else:
+        device = torch.device("cpu")
+    logger.info("Device: %s", device)
+
+    if args.smoke:
+        logger.info("Smoke test mode — random model, random data")
+        model, cfg = _build_smoke_model(device)
+        float_frames, int_frames, ctrl_inputs = _build_smoke_batch(
+            cfg, B=args.batch_size, T=4, device=device
+        )
+    else:
+        if not args.checkpoint:
+            parser.error("--checkpoint required when not in --smoke mode")
+        model, cfg = _load_checkpoint(args.checkpoint, device)
+        if args.encoded_file:
+            float_frames, int_frames, ctrl_inputs = _build_batch_from_encoded(
+                args.encoded_file, cfg, model.history_size, args.batch_size, device
+            )
+        else:
+            logger.warning(
+                "No --encoded-file provided; falling back to synthetic batch. "
+                "Diagnostic numbers will be noise."
+            )
+            float_frames, int_frames, ctrl_inputs = _build_smoke_batch(
+                cfg, B=args.batch_size, T=model.history_size + 1, device=device
+            )
+
+    logger.info(
+        "Input shapes: floats=%s ints=%s ctrls=%s",
+        tuple(float_frames.shape),
+        tuple(int_frames.shape),
+        tuple(ctrl_inputs.shape),
+    )
+
+    metrics = run_diagnostic_suite(model, float_frames, int_frames, ctrl_inputs)
+
+    print(_format_metrics(metrics))
+    print()
+    print(_interpret(metrics))
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(metrics, f, indent=2)
+        logger.info("Wrote metrics to %s", args.json_out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/training/jepa_diagnostics.py
+++ b/training/jepa_diagnostics.py
@@ -1,0 +1,492 @@
+"""Identity and quality diagnostics for the JEPA world model.
+
+Pure functions, no external dependencies (no sklearn), GPU-resident.
+Designed to run on a fixed held-out batch per epoch during training,
+or post-hoc on a trained checkpoint via scripts/run_jepa_diagnostics.py.
+
+The central concern: given that the encoder concatenates P0 and P1 features
+into a dedicated-slot input and runs them through an MLP trunk, does the
+trunk preserve player identity or collapse to swap-symmetric features?
+See docs/jepa-data-flow.md for the full trace and motivation.
+
+Diagnostics:
+    swap_test              — encoder collapse detector (P0↔P1 swap cosine sim)
+    per_player_probes      — linear decodability of P0/P1 physical quantities
+    relational_probe       — cross-player binding (e.g., P0.x - P1.x)
+    temporal_straightness  — LeWM's emergent diagnostic on latent trajectories
+
+All functions take a JEPAWorldModel (or its encoder) and a batch of
+(float_frames, int_frames, ctrl_inputs). They do not mutate state.
+
+Expected reading:
+    swap_test.mean_cosine_sim:  LOW (< ~0.5) = healthy identity preservation
+                                HIGH (> ~0.9) = identity collapse
+    swap_test.ditto_cosine_sim: sharpest signal — dittos have no character
+                                asymmetry, so position/velocity/action are
+                                the only identity signal
+    per_player probes R²:        HIGH (> 0.8) for position, percent = healthy
+                                LOW (< 0.3) = latent doesn't encode basic physics
+    relational probe R²:         HIGH for (P0.x - P1.x) = cross-player binding OK
+    temporal_straightness:       should INCREASE during training per LeWM
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+
+from models.encoding import EncodingConfig
+
+
+# ============================================================================
+# Swap test — P0↔P1 identity preservation
+# ============================================================================
+
+@torch.no_grad()
+def swap_p0_p1(
+    float_frames: torch.Tensor,
+    int_frames: torch.Tensor,
+    ctrl_inputs: Optional[torch.Tensor],
+    cfg: EncodingConfig,
+) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
+    """Swap P0 and P1 in the raw input tensors.
+
+    The float and int layouts are [P0 features || P1 features || (stage)], so
+    swapping is a straightforward re-concat of halves. The resulting tensors
+    represent "the same game situation with port assignments reversed."
+
+    A healthy, identity-aware encoder should produce a *different* latent for
+    swapped input, because slot-position has semantic meaning (P0 is always
+    the training-time "self" perspective).
+
+    Args:
+        float_frames: (..., F) where F = 2 * cfg.float_per_player
+        int_frames:   (..., I) where I = 2 * cfg.int_per_player + 1
+        ctrl_inputs:  (..., C) with C = cfg.ctrl_conditioning_dim, or None
+        cfg:          EncodingConfig for slot sizing
+
+    Returns:
+        (swapped_floats, swapped_ints, swapped_ctrls)
+        swapped_ctrls is None if ctrl_inputs was None.
+    """
+    fp = cfg.float_per_player
+    ipp = cfg.int_per_player
+
+    # Floats: [P0 (fp) || P1 (fp)]  →  [P1 (fp) || P0 (fp)]
+    swapped_floats = torch.cat(
+        [float_frames[..., fp : 2 * fp], float_frames[..., 0:fp]],
+        dim=-1,
+    )
+
+    # Ints: [P0 (ipp) || P1 (ipp) || stage (1)]  →  [P1 || P0 || stage]
+    swapped_ints = torch.cat(
+        [
+            int_frames[..., ipp : 2 * ipp],
+            int_frames[..., 0:ipp],
+            int_frames[..., 2 * ipp : 2 * ipp + 1],
+        ],
+        dim=-1,
+    )
+
+    # Controls: [p0_ctrl (13) || p1_ctrl (13) || (p0_thresh (5) || p1_thresh (5))]
+    # Matches JEPAFrameDataset._extract_ctrl packing.
+    swapped_ctrls = None
+    if ctrl_inputs is not None:
+        cd = cfg.controller_dim  # 13
+        p0_ctrl = ctrl_inputs[..., 0:cd]
+        p1_ctrl = ctrl_inputs[..., cd : 2 * cd]
+        parts = [p1_ctrl, p0_ctrl]
+        if cfg.ctrl_threshold_features:
+            # 5 analog threshold bits per player, in the same order
+            p0_thresh = ctrl_inputs[..., 2 * cd : 2 * cd + 5]
+            p1_thresh = ctrl_inputs[..., 2 * cd + 5 : 2 * cd + 10]
+            parts.extend([p1_thresh, p0_thresh])
+        swapped_ctrls = torch.cat(parts, dim=-1)
+
+    return swapped_floats, swapped_ints, swapped_ctrls
+
+
+@dataclass
+class SwapTestResult:
+    mean_cosine_sim: float
+    ditto_cosine_sim: float  # nan if no dittos in batch
+    nonditto_cosine_sim: float  # nan if no non-dittos in batch
+    n_ditto: int
+    n_nonditto: int
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "swap/mean_cosine_sim": self.mean_cosine_sim,
+            "swap/ditto_cosine_sim": self.ditto_cosine_sim,
+            "swap/nonditto_cosine_sim": self.nonditto_cosine_sim,
+            "swap/n_ditto": float(self.n_ditto),
+            "swap/n_nonditto": float(self.n_nonditto),
+        }
+
+
+@torch.no_grad()
+def swap_test(
+    encoder,
+    float_frames: torch.Tensor,
+    int_frames: torch.Tensor,
+    cfg: EncodingConfig,
+) -> SwapTestResult:
+    """Run P0↔P1 swap test on the encoder.
+
+    Encodes both the normal input and the P0/P1-swapped input, then measures
+    cosine similarity between corresponding latents.
+
+    Healthy: similarity is LOW (< ~0.5). Swap produces a genuinely different
+    latent because port position has meaning.
+
+    Collapsed: similarity is HIGH (> ~0.9). Encoder has learned swap-symmetric
+    features and lost player identity. Dittos will show the highest collapse.
+
+    Args:
+        encoder:      GameStateEncoder (or model.encoder) in eval mode
+        float_frames: (B, T, F) input
+        int_frames:   (B, T, I) input
+        cfg:          EncodingConfig for slot sizing and ditto detection
+
+    Returns:
+        SwapTestResult with mean, ditto, and non-ditto cosine similarities.
+    """
+    assert not encoder.training, (
+        "swap_test requires encoder in eval mode (BatchNorm in projector "
+        "would otherwise use batch stats). Call encoder.eval() first."
+    )
+
+    # Normal encoding
+    normal_embs = encoder(float_frames, int_frames)  # (B, T, D)
+
+    # Swapped encoding
+    swapped_floats, swapped_ints, _ = swap_p0_p1(
+        float_frames, int_frames, None, cfg
+    )
+    swapped_embs = encoder(swapped_floats, swapped_ints)  # (B, T, D)
+
+    # Flatten (B, T, D) → (B*T, D) for per-frame comparisons
+    n = normal_embs.flatten(0, 1)  # (B*T, D)
+    s = swapped_embs.flatten(0, 1)  # (B*T, D)
+    cos_sim = F.cosine_similarity(n, s, dim=-1)  # (B*T,)
+
+    # Ditto detection: P0 and P1 have the same character ID
+    # int layout per player: [action(0), jumps(1), character(2), ...]
+    ipp = cfg.int_per_player
+    p0_char = int_frames[..., 2]  # (B, T)
+    p1_char = int_frames[..., ipp + 2]  # (B, T)
+    is_ditto = (p0_char == p1_char).flatten()  # (B*T,)
+
+    mean = cos_sim.mean().item()
+    if is_ditto.any():
+        ditto = cos_sim[is_ditto].mean().item()
+    else:
+        ditto = float("nan")
+    if (~is_ditto).any():
+        nonditto = cos_sim[~is_ditto].mean().item()
+    else:
+        nonditto = float("nan")
+
+    return SwapTestResult(
+        mean_cosine_sim=mean,
+        ditto_cosine_sim=ditto,
+        nonditto_cosine_sim=nonditto,
+        n_ditto=int(is_ditto.sum().item()),
+        n_nonditto=int((~is_ditto).sum().item()),
+    )
+
+
+# ============================================================================
+# Linear probes — decodability of game state from the latent
+# ============================================================================
+
+def linear_probe_r2(
+    embeddings: torch.Tensor,
+    targets: torch.Tensor,
+    val_frac: float = 0.2,
+) -> float:
+    """Fit a linear regression from embeddings to targets with a holdout split.
+
+    Pure torch, closed-form least squares — no sklearn dependency.
+
+    Args:
+        embeddings: (N, D) — flattened latents
+        targets:    (N,)   — continuous target (e.g., P0.x)
+        val_frac:   fraction of samples held out for R² evaluation
+
+    Returns:
+        R² score on the validation split (can be negative for very bad fits).
+    """
+    if embeddings.ndim != 2:
+        raise ValueError(f"embeddings must be 2D, got {embeddings.shape}")
+    if targets.ndim != 1 or targets.shape[0] != embeddings.shape[0]:
+        raise ValueError(
+            f"targets must be 1D matching embeddings[0]: "
+            f"emb {embeddings.shape}, targets {targets.shape}"
+        )
+
+    N, D = embeddings.shape
+    device = embeddings.device
+    dtype = torch.float32
+
+    emb = embeddings.to(dtype)
+    y = targets.to(dtype)
+
+    val_n = max(1, int(N * val_frac))
+    perm = torch.randperm(N, device=device)
+    val_idx = perm[:val_n]
+    train_idx = perm[val_n:]
+    if train_idx.numel() < D + 1:
+        # Not enough training samples for a unique solution — fall back to
+        # a ridge-regularized fit so we still return a finite R².
+        return _ridge_r2(emb, y, train_idx, val_idx, ridge=1e-3)
+
+    ones_train = torch.ones(train_idx.numel(), 1, device=device, dtype=dtype)
+    ones_val = torch.ones(val_n, 1, device=device, dtype=dtype)
+    X_train = torch.cat([emb[train_idx], ones_train], dim=-1)
+    X_val = torch.cat([emb[val_idx], ones_val], dim=-1)
+    y_train = y[train_idx]
+    y_val = y[val_idx]
+
+    # Closed-form least squares
+    try:
+        w = torch.linalg.lstsq(X_train, y_train.unsqueeze(-1)).solution.squeeze(-1)
+    except RuntimeError:
+        return _ridge_r2(emb, y, train_idx, val_idx, ridge=1e-3)
+
+    y_pred = X_val @ w
+    ss_res = ((y_val - y_pred) ** 2).sum()
+    ss_tot = ((y_val - y_val.mean()) ** 2).sum().clamp_min(1e-12)
+    r2 = (1.0 - ss_res / ss_tot).item()
+    return r2
+
+
+def _ridge_r2(
+    emb: torch.Tensor,
+    y: torch.Tensor,
+    train_idx: torch.Tensor,
+    val_idx: torch.Tensor,
+    ridge: float,
+) -> float:
+    """Ridge-regularized least squares fallback when samples < features."""
+    device = emb.device
+    dtype = emb.dtype
+    X_train = torch.cat(
+        [emb[train_idx], torch.ones(train_idx.numel(), 1, device=device, dtype=dtype)],
+        dim=-1,
+    )
+    X_val = torch.cat(
+        [emb[val_idx], torch.ones(val_idx.numel(), 1, device=device, dtype=dtype)],
+        dim=-1,
+    )
+    y_train = y[train_idx]
+    y_val = y[val_idx]
+    D = X_train.shape[-1]
+    A = X_train.T @ X_train + ridge * torch.eye(D, device=device, dtype=dtype)
+    b = X_train.T @ y_train
+    w = torch.linalg.solve(A, b)
+    y_pred = X_val @ w
+    ss_res = ((y_val - y_pred) ** 2).sum()
+    ss_tot = ((y_val - y_val.mean()) ** 2).sum().clamp_min(1e-12)
+    return (1.0 - ss_res / ss_tot).item()
+
+
+def extract_probe_targets(
+    float_frames: torch.Tensor,
+    int_frames: torch.Tensor,
+    cfg: EncodingConfig,
+) -> dict[str, torch.Tensor]:
+    """Extract interpretable per-player ground truth for linear probing.
+
+    The float layout per player (from EncodingConfig):
+        [percent, x, y, shield, (5 velocity dims), ...]
+
+    So P0.percent is at index 0, P0.x at 1, P0.y at 2, etc.
+    P1 is offset by float_per_player.
+
+    Args:
+        float_frames: (B, T, 2*fp)
+        int_frames:   (B, T, 2*ipp+1)
+        cfg:          EncodingConfig
+
+    Returns:
+        Flat dict of named (B*T,) tensors ready for linear_probe_r2.
+    """
+    fp = cfg.float_per_player
+    ipp = cfg.int_per_player
+
+    # Core continuous layout: percent=0, x=1, y=2, shield=3
+    targets = {
+        "p0_percent": float_frames[..., 0].flatten(),
+        "p0_x": float_frames[..., 1].flatten(),
+        "p0_y": float_frames[..., 2].flatten(),
+        "p0_shield": float_frames[..., 3].flatten(),
+        "p1_percent": float_frames[..., fp + 0].flatten(),
+        "p1_x": float_frames[..., fp + 1].flatten(),
+        "p1_y": float_frames[..., fp + 2].flatten(),
+        "p1_shield": float_frames[..., fp + 3].flatten(),
+        # Relational targets — require cross-player binding in the latent
+        "rel_x": (float_frames[..., 1] - float_frames[..., fp + 1]).flatten(),
+        "rel_y": (float_frames[..., 2] - float_frames[..., fp + 2]).flatten(),
+        "rel_percent": (float_frames[..., 0] - float_frames[..., fp + 0]).flatten(),
+    }
+    return targets
+
+
+@dataclass
+class ProbeResults:
+    per_player: dict[str, float]
+    relational: dict[str, float]
+
+    def to_dict(self) -> dict[str, float]:
+        out = {}
+        for k, v in self.per_player.items():
+            out[f"probe/{k}_r2"] = v
+        for k, v in self.relational.items():
+            out[f"probe/{k}_r2"] = v
+        return out
+
+
+@torch.no_grad()
+def run_linear_probes(
+    encoder,
+    float_frames: torch.Tensor,
+    int_frames: torch.Tensor,
+    cfg: EncodingConfig,
+    val_frac: float = 0.2,
+) -> ProbeResults:
+    """Encode the batch and fit linear probes for per-player and relational targets.
+
+    Per-player probes (separate P0 and P1):
+        percent, x, y, shield
+
+    Relational probes (cross-player binding):
+        rel_x   = P0.x - P1.x
+        rel_y   = P0.y - P1.y
+        rel_percent = P0.percent - P1.percent
+
+    A healthy representation fits all per-player probes with high R² (> 0.8
+    expected for positions and percent, which are directly encoded inputs).
+    Relational probes test whether the latent encodes cross-player structure
+    rather than just stacking independent per-player slots.
+
+    Args:
+        encoder:      GameStateEncoder in eval mode
+        float_frames: (B, T, F)
+        int_frames:   (B, T, I)
+        cfg:          EncodingConfig
+        val_frac:     fraction held out for R²
+
+    Returns:
+        ProbeResults with per_player and relational R² dicts.
+    """
+    assert not encoder.training, "run_linear_probes requires encoder.eval()"
+
+    embs = encoder(float_frames, int_frames)  # (B, T, D)
+    flat_embs = embs.flatten(0, 1)  # (B*T, D)
+
+    targets = extract_probe_targets(float_frames, int_frames, cfg)
+
+    per_player_keys = ["p0_percent", "p0_x", "p0_y", "p0_shield",
+                       "p1_percent", "p1_x", "p1_y", "p1_shield"]
+    relational_keys = ["rel_x", "rel_y", "rel_percent"]
+
+    per_player = {k: linear_probe_r2(flat_embs, targets[k], val_frac)
+                  for k in per_player_keys}
+    relational = {k: linear_probe_r2(flat_embs, targets[k], val_frac)
+                  for k in relational_keys}
+
+    return ProbeResults(per_player=per_player, relational=relational)
+
+
+# ============================================================================
+# Temporal straightness — LeWM's emergent diagnostic
+# ============================================================================
+
+@torch.no_grad()
+def temporal_straightness(embeddings: torch.Tensor) -> float:
+    """Cosine similarity of consecutive latent velocity vectors.
+
+    LeWM (arXiv 2603.19312) reports that latent trajectories become
+    increasingly "straight" during training — consecutive velocity vectors
+    point in similar directions — as an emergent property with no explicit
+    regularization. Increasing straightness over training epochs is a
+    qualitative health signal for the predictor.
+
+    Args:
+        embeddings: (B, T, D) with T >= 3
+
+    Returns:
+        Mean cosine similarity of consecutive velocity vectors.
+        NaN if T < 3.
+    """
+    if embeddings.shape[1] < 3:
+        return float("nan")
+
+    # Velocity: first difference along time
+    vel = embeddings[:, 1:] - embeddings[:, :-1]  # (B, T-1, D)
+    # Consecutive velocity pairs
+    v1 = vel[:, :-1]  # (B, T-2, D)
+    v2 = vel[:, 1:]   # (B, T-2, D)
+    sim = F.cosine_similarity(v1, v2, dim=-1)  # (B, T-2)
+    return sim.mean().item()
+
+
+# ============================================================================
+# Top-level: run the whole diagnostic suite
+# ============================================================================
+
+@torch.no_grad()
+def run_diagnostic_suite(
+    model,
+    float_frames: torch.Tensor,
+    int_frames: torch.Tensor,
+    ctrl_inputs: Optional[torch.Tensor] = None,
+) -> dict[str, float]:
+    """Run the full JEPA diagnostic suite on a batch.
+
+    Intended to be called once per epoch on a fixed held-out batch.
+    Returns a flat dict of metrics suitable for wandb logging.
+
+    Runs:
+        - swap_test       (swap/mean, swap/ditto, swap/nonditto)
+        - run_linear_probes (probe/p0_x_r2, probe/rel_x_r2, ...)
+        - temporal_straightness (emergent/straightness)
+
+    Args:
+        model: JEPAWorldModel — must have .encoder and .cfg
+        float_frames: (B, T, F)
+        int_frames:   (B, T, I)
+        ctrl_inputs:  (B, T, C) or None — currently unused by suite,
+                      reserved for future predictor-level diagnostics
+
+    Returns:
+        Flat dict of metric_name → float, ready for wandb.log().
+    """
+    was_training = model.training
+    model.eval()
+    try:
+        cfg = model.cfg
+        encoder = model.encoder
+
+        metrics: dict[str, float] = {}
+
+        # Swap test (encoder-level)
+        swap_result = swap_test(encoder, float_frames, int_frames, cfg)
+        metrics.update(swap_result.to_dict())
+
+        # Linear probes (encoder-level)
+        probe_result = run_linear_probes(encoder, float_frames, int_frames, cfg)
+        metrics.update(probe_result.to_dict())
+
+        # Temporal straightness on the encoded sequence
+        embs = encoder(float_frames, int_frames)
+        metrics["emergent/straightness"] = temporal_straightness(embs)
+
+        return metrics
+    finally:
+        if was_training:
+            model.train()


### PR DESCRIPTION
## Summary

Pure additions (no edits to in-flight files) shipping the JEPA identity diagnostic suite and a detailed data-flow reference. Scoped to avoid colliding with Scav's in-flight implementation of the previous review's blocking fixes in `models/jepa/*.py`, `data/jepa_dataset.py`, and `training/jepa_trainer.py`.

### The concern

The encoder concatenates P0 and P1 features into dedicated slots, so the exact CLIP bag-of-words collapse doesn't apply structurally — there's no pooling step that loses positional information. But the trunk MLP is free to **learn** swap-symmetric features, and unlike Mamba2, **JEPA's loss does not explicitly penalize player identity collapse**. SIGReg regularizes the latent distribution, MSE measures predictor self-consistency, neither cares who is who. `pred_loss` only indirectly requires identity preservation, to the extent that specific next-frame predictions are sensitive to it. Dittos (same character, both ports) are where this breaks first — character embeddings give no asymmetry signal and all the identity has to come from positional/kinematic slots.

This is structurally **more at risk than Mamba2**, whose per-player prediction heads compute separate MSEs for P0's next x and P1's next x at every gradient step, forcing distinct representation.

### What's in this PR

**NEW `docs/jepa-data-flow.md`** — step-by-step trace of how P0/P1 reach the latent through `GameStateEncoder`, with explicit call-outs for where identity can fail, why JEPA is structurally weaker than Mamba2 on this axis, and which diagnostic catches each failure mode. Reference page for anyone touching the encoder going forward.

**NEW `training/jepa_diagnostics.py`** — closed-form, GPU-resident, no sklearn dependency:

- \`swap_test(encoder, float_frames, int_frames, cfg)\` — swaps P0↔P1 in raw inputs, re-encodes, returns cosine similarity (mean + ditto-only + non-ditto-only). Low = healthy, high = collapsed. Ditto split is the sharpest signal.
- \`run_linear_probes(encoder, ...)\` — fits per-player probes (P0/P1 × {percent, x, y, shield}) and relational probes (rel_x, rel_y, rel_percent = P0 - P1) with held-out R².
- \`temporal_straightness(embeddings)\` — LeWM's emergent diagnostic, cosine similarity of consecutive latent velocities.
- \`run_diagnostic_suite(model, ...)\` — one-shot that runs everything, handles eval-mode toggling, returns a flat dict ready for \`wandb.log()\`.

**NEW \`scripts/run_jepa_diagnostics.py\`** — CLI to run the suite on a trained checkpoint (or in \`--smoke\` mode with a random model + synthetic batch for development). Prints grouped metrics plus a plain-English interpretation section; optional \`--json-out\` for machine-readable output.

**MOD \`docs/run-cards/e028a-jepa-baseline.md\`**:
- Identity diagnostics added to the Evaluation section with healthy/collapsed thresholds.
- Identity collapse promoted to **Key Risk #1** with explicit reasoning for why JEPA is more at risk than Mamba2.
- **Pre-registered e028-identity-fix**: per-player shared-weight sub-encoder + cross-attention fusion (AlphaZero pattern) to run immediately if diagnostics fire on e028a. Don't debate the architecture after observing the failure — ship the ready replacement.

**MOD \`docs/HANDOFF.md\`** — identity preservation section with the integration instructions for Scav to wire the suite into \`JEPATrainer\` when ready.

## How to integrate (for Scav)

Not done in this PR to avoid colliding with in-flight work. When ready:

1. In \`JEPATrainer.__init__\`, after the val loader is built, pull a fixed diagnostic batch once (\`val_dataset.get_batch(np.arange(256))\`) and stash it on \`self.diagnostic_batch\` as GPU tensors.
2. At the end of \`train()\`'s per-epoch block (after \`_val_epoch()\`, before checkpointing):

\`\`\`python
from training.jepa_diagnostics import run_diagnostic_suite
if self.diagnostic_batch is not None:
    diag = run_diagnostic_suite(self.model, *self.diagnostic_batch)
    combined.update(diag)
    if wandb and wandb.run:
        wandb.log(diag)
\`\`\`

\`run_diagnostic_suite\` handles \`model.eval()\` / restore internally.

## Reporting policy

Swap similarity (mean + ditto) and per-player probe R² are **required reported numbers** in every JEPA run card closeout, alongside RC. **Not** a kept/discarded gate yet — we need 5–10 runs' worth of observed values before setting a principled threshold. Until then: report, track, flag anomalies (\`ditto_cosine_sim > 0.9\` or any per-player probe R² < 0.3).

## Test plan

- [x] Smoke tested via \`python -m scripts.run_jepa_diagnostics --smoke --batch-size 64\` — all functions run end-to-end on random model + synthetic data, no crashes, ditto detection works (found 69 ditto samples out of 256 in a seeded run).
- [ ] End-to-end validation on a real JEPA checkpoint once Scav's Modal entry point lands and e028a produces \`checkpoints/e028a-jepa-baseline/best.pt\`.
- [ ] Trainer wire-up verified by Scav before first Modal run.
- [ ] Swap test + per-player probes reported in the e028a closeout alongside RC.

## Not in this PR

- BatchNorm \`eval()\` guard in \`JEPAWorldModel.rollout()\` — Scav is handling from previous review.
- \`assert cfg.lookahead == 0 and not cfg.press_events\` in \`JEPAFrameDataset\` — Scav is handling from previous review.
- \`scripts/modal_train_jepa.py\` — Scav is building.
- Trainer integration of the diagnostic suite — intentionally deferred, see above.
- Mamba2 verification of the same identity concern — pulling into a follow-up after e028a launches, to keep context focused.

## References

- \`docs/jepa-data-flow.md\` — the data-flow trace
- \`docs/HANDOFF.md\` — full review response (previous) + identity section (this PR)
- \`docs/run-cards/e028a-jepa-baseline.md\` — updated evaluation + risks + lineage

🤖 Generated with [Claude Code](https://claude.com/claude-code)