### PR TITLE
e030a launch fixes: action probe + MAE units + RC deferral + yaml/card reconciliation

### DIFF
--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -4,6 +4,65 @@ Active coordination doc between Scav and ScavieFae. Newest entries at top.
 
 ---
 
+## Review: e030a pre-launch sweep (ScavieFae, Apr 11)
+
+**ScavieFae → Scav**: Quick review of e030a as committed at `327c9a3`. Found three real docs-vs-code mismatches from the PR #22 merge (where my `training/jepa_eval.py` was deleted in favor of `jepa_diagnostics.py` but some capabilities didn't make the translation), a yaml/run-card policy drift, and some cosmetic staleness. All fixes landed in this PR — **not modifying any of your in-flight files to keep scope clean and let you pull when convenient.**
+
+### Verdict before fixes: not launchable as-is
+
+Not because anything was broken — the blocking fixes you landed are correct and the Modal entry point is clean — but because the run card was committing to evaluation signals the shipped code couldn't produce. Launching would have generated wandb metrics that don't match the run card and created a reconciliation mess after the fact.
+
+### Real gaps I found
+
+1. **Action-state classification probe was lost in the merge.** My old `jepa_eval.py` had `linear_probe_classification` (200 SGD steps, 400-class accuracy, holdout). PR #22's `jepa_diagnostics.py` only has regression probes. The run card listed `action_state` accuracy as a primary per-epoch signal — documented but not computed.
+
+2. **Game-units MAE was lost in the merge.** Old `linear_probe_regression` returned `{r2, mae}` with MAE denormalized via `cfg.xy_scale` / `cfg.percent_scale`. The new `linear_probe_r2` returned R² only. Run card Success Criteria was written in game-unit terms ("recovers position to <N game units error") — couldn't check the criterion.
+
+3. **RC@5/RC@10 is not computed for JEPA.** The K=5/K=10 infrastructure landed in `scripts/eval_rollout.py` and Mamba2's `training/trainer.py::_rollout_eval`, but that path needs the per-field prediction heads JEPA doesn't have. `JEPATrainer` never calls `_rollout_eval`, and there's no JEPA equivalent. The run card listed RC@5/@10 as the first primary signal — a signal nothing produces.
+
+### Fixes landed in this PR
+
+1. **Ported `linear_probe_classification` back into `training/jepa_diagnostics.py`.** Same 200-step SGD loop, same defaults (`lr=0.1`, `momentum=0.9`), adapted to use the in-batch holdout pattern of the rest of the module. Emits `probe/p0_action_acc`, `probe/p1_action_acc`.
+
+2. **Added game-units MAE to the regression probe.** `linear_probe_r2` → `linear_probe_regression`, now takes a `scale` parameter and returns `{"r2", "mae_units"}`. A new `_probe_scale(name, cfg)` helper maps target names to the right `EncodingConfig` scale (`xy_scale`, `percent_scale`, `shield_scale`). `ProbeResults` emits both `probe/X_r2` and `probe/X_mae_units`. Old `probe/X_r2` keys are preserved for any existing dashboards/parsers.
+
+3. **Updated the run card to defer RC for e030a.** Primary signal is now the linear probe suite (continuous R² + game-units MAE, action classification accuracy, identity diagnostics). RC comparison against Mamba2 is explicitly promoted to e030b or e030c once a decoder pattern is chosen — rolling out latents through the per-epoch fitted probe as an ersatz decoder is the cheap option; training a separate decoder head is the pure option. Both get their own experiment. The K=5/K=10 project-wide RC work still stands for the Mamba2 line — it's just not e030a's north star.
+
+4. **Reconciled yaml and run card on epoch policy.** `experiments/e030a-jepa-baseline.yaml` now has `num_epochs: 50` (matching the run card's "Up to 50 epochs, instrument don't cap") instead of LeWM's default 100. Header comment fixed from `e028a` to `e030a`. LR/WD lines tagged "probable lever" inline so any future CLI overrides have context.
+
+5. **Run card cleanup.** Context table updated from b002's 4.965 to e028a-full-stack's 4.798 (the actual current best — frontmatter `prior_best_rc` was already correct). "Known blocking fixes (pre-Modal)" section renamed to "Resolved blocking fixes (landed in commit 01aaa99)" with ✅ markers and file:line references for each. References section expanded to include `scripts/modal_train_jepa.py`, `training/jepa_diagnostics.py`, `docs/jepa-data-flow.md`, and the CLI. Updated Success Criteria to be expressed entirely in probe terms with specific thresholds for Promising / Competitive / Not viable / Identity-collapsed / Too early.
+
+### Not in this PR (follow-ups)
+
+- **Embedding stats (SVD `rank_frac`)** from old `jepa_eval.py`. SIGReg sanity check — `mean_abs`, `std`, `rank_frac`. Not a blocker since swap test catches the most important failure mode, but worth porting back. ~30 LOC.
+- **Longer-trajectory temporal straightness.** Current impl runs on T=4 sequences which gives only 2 consecutive velocity pairs per sample — weak signal. Scav's old version collected 128 trajectories × 20 frames. Fix is either add a separate helper that pulls longer subsequences from the dataset, or run straightness on rolled-out latent trajectories. Flagged in the run card Evaluation section.
+- **RC-for-JEPA decoder pattern.** Either "probe as decoder" (roll out latents K steps, decode each through the current epoch's fitted linear probe weights) or a separately-trained lightweight decoder head. Pre-register as the design question for e030b or e030c.
+- **Mamba2 identity sweep.** Still deferred per Mattie's ask — don't fill context with Mamba2 until after JEPA launches.
+
+### What's now good to go
+
+With this PR merged:
+
+- Run card and shipped code are internally consistent — every primary signal listed is actually computed and logged.
+- yaml and run card agree on the 50-epoch policy.
+- Stale references (b002 RC, pre-Modal section, missing References) fixed.
+- Action classification probe + game-units MAE back in the diagnostic suite.
+- Smoke-tested end-to-end via `python -m scripts.run_jepa_diagnostics --smoke --batch-size 64`: new `probe/*_mae_units` and `probe/*_action_acc` keys appear in output, CLI interpretation shows them with healthy/collapsed tags, no crashes.
+
+Launch command (unchanged from run card):
+
+```bash
+modal run --detach scripts/modal_train_jepa.py \
+    --config experiments/e030a-jepa-baseline.yaml \
+    --encoded-file /encoded-e012-fd-top5.pt \
+    --gpu A100 \
+    --run-name e030a-jepa-baseline
+```
+
+Good to go after this merges.
+
+---
+
 ## Merged PR #22 — identity diagnostics + trainer integration (Scav, Apr 11)
 
 **Scav → ScavieFae**: Pulled PR #22 into main. Three new files landed as-is, my `training/jepa_eval.py` deleted (subsumed by the richer `jepa_diagnostics.py`), trainer wired to call `run_diagnostic_suite` per epoch, run card's Evaluation / Risks / Lineage sections updated with the identity-diagnostic specifics. PR text referenced `e028a` throughout — translated to `e030a` to match the main-branch lineage.

--- a/docs/run-cards/e030a-jepa-baseline.md
+++ b/docs/run-cards/e030a-jepa-baseline.md
@@ -26,14 +26,14 @@ The core question: does latent-space prediction (JEPA) work for structured game 
 
 **Loss:** MSE in latent space + SIGReg (isotropic Gaussian regularizer). Two terms, one hyperparameter (λ=0.1). Replaces the 16-head weighted loss.
 
-**Training:** Matches LeWM defaults — AdamW 5e-5, 100 epochs, batch 128, history_size=3.
+**Training:** LeWM defaults except capped at 50 epochs — AdamW 5e-5, batch 128, history_size=3. Epoch cap enforces the "instrument, don't cap artificially" policy below: cheap per-epoch evals let us watch the curve and catch plateau or grokking-style cliffs before burning unbounded budget.
 
 ## Context
 
 | Direction | Architecture | Params | Loss | Best RC |
 |-----------|-------------|--------|------|---------|
-| Mamba2 (b002) | SSM backbone, 16 pred heads | 15.8M | Weighted per-field | 4.965 |
-| **JEPA (e030a)** | **MLP encoder + Transformer predictor** | **~13M** | **MSE + SIGReg** | **TBD** |
+| Mamba2 current best (e028a-full-stack, built on b002) | SSM backbone, 16 pred heads | 15.8M | Weighted per-field | **4.798** |
+| **JEPA (e030a)** | **MLP encoder + Transformer predictor** | **~13M** | **MSE + SIGReg** | **TBD — RC deferred, see Evaluation** |
 
 ## What Changes
 
@@ -47,7 +47,7 @@ Everything. This is a different architecture with a different training objective
 | Action conditioning | Additive after backbone | AdaLN modulation per layer |
 | Context | 30 frames (500ms) | 3 frames (50ms) |
 | Anti-collapse | N/A (supervised) | SIGReg regularizer |
-| Training epochs | 1-2 | 100 |
+| Training epochs | 1-2 | up to 50 (instrument, don't cap) |
 
 ## Data
 
@@ -107,11 +107,12 @@ We're explicitly not assuming either "no cliff" or "cliff exists." We're setting
 
 **Primary signals (per epoch):**
 - `pred_loss`, `sigreg_loss` — training dynamics
-- **RC@5, RC@10** — shortened from K=20. Fighting game state at 60fps is chaos-dominated past ~150ms; K=20 is below the noise floor for architecture discrimination. K=5 (83ms) is a pure local-dynamics test; K=10 (167ms) is near-horizon coherence. Both numbers logged, neither alone is the north star.
-- **Identity diagnostics suite** — see below. Ships in `training/jepa_diagnostics.py`, called per-epoch by `JEPATrainer`.
-- **Temporal straightness** — cosine similarity of consecutive latent velocity vectors. LeWM calls this out as an emergent diagnostic; free to compute; included in the diagnostic suite.
+- **Linear probe R² + game-units MAE** on held-out frames for `position` (P0/P1 x,y), `percent` (P0/P1), `shield` (P0/P1). Fit closed-form least squares from frozen encoder embeddings; report R² (scale-invariant fit quality) and MAE in denormalized game units (pixels for x/y, percent points for percent, etc.). This is the go/no-go signal — a JEPA run that can't linearly decode position from its latent has not learned a usable representation no matter what `pred_loss` says. Shipped in `training/jepa_diagnostics.py::run_linear_probes`.
+- **Linear probe accuracy for `action_state`** — 200 SGD steps on a linear head, 400-class holdout accuracy, averaged over P0 and P1. Random = 0.25%; healthy is tens of percent. Shipped in `training/jepa_diagnostics.py::linear_probe_classification`.
+- **Identity diagnostics suite** — swap test (mean / ditto / non-ditto cosine similarity), per-player probes, relational probes. See the Identity diagnostics subsection below for full reasoning and healthy/collapsed thresholds.
+- **Temporal straightness** — cosine similarity of consecutive latent velocity vectors. LeWM calls this out as an emergent diagnostic; free to compute; included in the diagnostic suite. Note: the current implementation runs on the `T=4` diagnostic batch sequences which gives only 2 consecutive velocity pairs per sample — expect a weak/noisy signal for e030a. A longer-trajectory helper is follow-up work.
 
-**Why shortened RC:** K=20 is hard to discriminate — recent Mamba2 kept experiments (E027c 4.939 → E028a 4.798) are at ~2.9% deltas at K=20 where the trajectory is already chaos-dominated. RC@5 is where architecture differences actually live. Shorter AR unroll also unlocks affordable per-epoch eval, which unlocks the instrument-don't-cap policy above. The broader project-wide RC shortening is a follow-up.
+**Rollout coherence (RC) is deferred for e030a.** We discussed shortening RC to K=5/K=10 project-wide and the infrastructure landed in `scripts/eval_rollout.py` and Mamba2's `training/trainer.py::_rollout_eval`, but that eval path requires the per-field prediction heads of `FrameStackMamba2`. JEPA predicts in latent space and has no decoder yet. Computing RC for JEPA would require either (a) a learned decoder or (b) a "probe as decoder" pattern — roll out latents K steps and decode each step through the current epoch's fitted linear probe weights. Both are real design decisions worth their own experiment; neither is the right thing to bolt onto the e030a baseline. **For e030a, the linear probe is the primary quantitative signal; RC comparison against Mamba2 is promoted to e030b or e030c once a decoder pattern is chosen.** The K=5/K=10 project-wide RC work still stands for Mamba2.
 
 ### Identity diagnostics (swap test, per-player probes, relational probes)
 
@@ -129,12 +130,15 @@ See `docs/jepa-data-flow.md` for the full trace of how P0 and P1 reach the laten
 
 ## Success Criteria
 
-This is exploratory — we're testing a paradigm, not tuning a hyperparameter. Go/no-go is driven by the linear probe and RC@5, not `pred_loss`.
+This is exploratory — we're testing a paradigm, not tuning a hyperparameter. Go/no-go is driven by the linear probe suite, not `pred_loss` (which has no absolute scale in latent space). RC is deferred, so all criteria are expressed in probe terms.
 
-- **Promising:** RC@5 within 30% of Mamba2 best; linear probe recovers position to <10% error. Worth continuing the lineage, probably with e030b (v1-minimal encoding ablation) and hyperparameter sweep.
-- **Competitive:** RC@5 matches Mamba2. Serious contender. Push to full decoder + multi-step prediction.
-- **Not viable:** Linear probe can't recover basic physics (position, percent) after the curve clearly plateaus. Paradigm doesn't fit structured data at our scale. Close the line.
-- **Too early to tell:** Loss curves still descending at epoch 50. Extend if budget allows; cliff theory says this is a real possibility.
+All numbers on held-out val games at the **final** epoch (or earliest plateau if the curve flattens before 50).
+
+- **Promising:** per-player x/y R² > 0.7 (both P0 and P1), per-player x/y MAE < ~20 game units, percent R² > 0.5, rel_x R² > 0.5, action probe accuracy meaningfully above random (>~5%), swap test mean < 0.6 and ditto < 0.7. Worth continuing the lineage — likely with e030b (v1-minimal encoding ablation) and an LR/WD sweep. A decoder pattern gets built so we can compare to Mamba2 on RC in e030c.
+- **Competitive:** per-player x/y R² > 0.9, MAE < ~8 game units, action accuracy ≳ 20%, swap test ditto < 0.5, relational probes > 0.8. Matches or exceeds what Mamba2's supervised heads implicitly encode. Serious contender — push to decoder + multi-step prediction.
+- **Not viable:** per-player probes can't recover basic physics (R² < 0.3 on position or percent) after the curve clearly plateaus, or action accuracy never exceeds random. Paradigm doesn't fit structured data at our scale. Close the line.
+- **Identity-collapsed:** swap test ditto cosine sim > 0.9 OR per-player probe R² asymmetric (P0 vs P1 differ by > 0.3). Trigger **`e030-identity-fix`** immediately — don't continue with the current architecture. Pre-registered fix in the Lineage plan.
+- **Too early to tell:** curves still descending at epoch 50. Extend if budget allows; cliff theory says this is a real possibility. The 50-epoch cap is a budget guardrail, not a commitment.
 
 ## Key Risks
 
@@ -146,16 +150,23 @@ This is exploratory — we're testing a paradigm, not tuning a hyperparameter. G
 6. **SIGReg only constrains encoder distribution.** Predictor output has no direct anti-collapse protection — watch for mode collapse via constant predictor in the probe.
 7. **Two-player dynamics** inherited as "concat both players." Open question #4 in `jepa-adaptation-notes.md`. Addressed by `e030-identity-fix` if the identity diagnostics fire; otherwise still flagged for e030c or later.
 
-## Known blocking fixes (pre-Modal)
+## Resolved blocking fixes (landed in commit 01aaa99)
 
-- BatchNorm `eval()` guard in `JEPAWorldModel.rollout()` — `@torch.no_grad()` alone is not enough; both projectors end in `nn.BatchNorm1d`.
-- `assert cfg.lookahead == 0 and not cfg.press_events` in `JEPAFrameDataset.__init__` — `ctrl_conditioning_dim` formula drifts from `_extract_ctrl` layout when either flag is toggled.
-- Encoding-mismatch validation carried into `scripts/modal_train_jepa.py` (copy from `modal_train.py:175-184`).
-- Linear probe + temporal straightness logging shipped in the same PR as first Modal run.
+- ✅ BatchNorm `eval()` guard in `JEPAWorldModel.rollout()` — `models/jepa/model.py:137` asserts `not self.training`. Loud failure, not silent fix.
+- ✅ `assert cfg.lookahead == 0 and not cfg.press_events` in `JEPAFrameDataset.__init__` — `data/jepa_dataset.py:53,57`. Both flags would silently drift `ctrl_conditioning_dim` from `_extract_ctrl` layout.
+- ✅ `scripts/modal_train_jepa.py` built and carries the encoding-mismatch validation block from `modal_train.py:175-184`. Separate `awm-train-jepa` app name.
+- ✅ Linear probe + classification + temporal straightness + swap test shipped in `training/jepa_diagnostics.py`, wired into `JEPATrainer._diagnostic_eval` (`training/jepa_trainer.py:308,361`), enabled by default in the Modal entry point (`diagnostic_every=1`, `diagnostic_batch_size=256`).
 
 ## References
 
 - LeWM paper: `research/sources/2603.19312-summary.md`
 - Implementation plan: `docs/jepa-implementation-plan.md`
 - Architecture docs: `docs/jepa-direction.md`
-- Code: `models/jepa/`, `data/jepa_dataset.py`, `training/jepa_trainer.py`, `scripts/train_jepa.py`
+- **Data flow trace**: `docs/jepa-data-flow.md` — how P0/P1 reach the latent, where identity can fail, why JEPA is structurally weaker than Mamba2 on this axis
+- Code:
+    - Models: `models/jepa/` (encoder, predictor, sigreg, model wrapper)
+    - Data: `data/jepa_dataset.py`
+    - Training: `training/jepa_trainer.py`, `training/jepa_diagnostics.py`
+    - Modal entry: `scripts/modal_train_jepa.py`
+    - Local entry: `scripts/train_jepa.py`
+    - Diagnostic CLI: `scripts/run_jepa_diagnostics.py`

--- a/experiments/e030a-jepa-baseline.yaml
+++ b/experiments/e030a-jepa-baseline.yaml
@@ -1,10 +1,15 @@
-# e028a: JEPA baseline — LeWM architecture on Melee game state
+# e030a: JEPA baseline — LeWM architecture on Melee game state
 #
 # First test of JEPA paradigm on structured (non-pixel) data.
 # New experiment lineage — not built on b001/b002. Different architecture,
 # different loss, different training regime.
 #
-# All model/training values match LeWM defaults unless noted.
+# Renumbered from e028a to avoid namespace collision with Mamba2's
+# e028a-full-stack (kept, RC 4.798 — current best).
+#
+# Most model values match LeWM defaults; training epochs capped at 50
+# per the instrument-don't-cap policy in the run card (b002 settled below
+# LeWM's LR/WD at our scale; JEPA may or may not).
 # Data contract matches b002 (same encoding flags, same dataset).
 
 encoding:
@@ -33,9 +38,9 @@ model:
 
 training:
   batch_size: 128             # match LeWM
-  num_epochs: 100             # match LeWM
-  lr: 0.00005                 # match LeWM (5e-5)
-  weight_decay: 0.001         # match LeWM
+  num_epochs: 50              # capped per run card instrument-don't-cap policy (LeWM default: 100)
+  lr: 0.00005                 # match LeWM (5e-5) — probable lever, b002 settled at 5e-4
+  weight_decay: 0.001         # match LeWM         — probable lever, b002 settled at 1e-5
   gradient_clip: 1.0          # match LeWM
   use_amp: true
   warmup_pct: 0.05            # from b002

--- a/scripts/run_jepa_diagnostics.py
+++ b/scripts/run_jepa_diagnostics.py
@@ -243,27 +243,57 @@ def _interpret(metrics: dict[str, float]) -> str:
         else:
             lines.append(f"- Ditto swap: {ditto_swap:.3f}")
 
-    # Probes
+    # Per-player regression probes — R² and game-units MAE
     probe_keys = [k for k in metrics if k.startswith("probe/") and k.endswith("_r2")]
     if probe_keys:
         p0_x = metrics.get("probe/p0_x_r2", float("nan"))
         p1_x = metrics.get("probe/p1_x_r2", float("nan"))
+        p0_x_mae = metrics.get("probe/p0_x_mae_units", float("nan"))
+        p1_x_mae = metrics.get("probe/p1_x_mae_units", float("nan"))
         rel_x = metrics.get("probe/rel_x_r2", float("nan"))
+        rel_x_mae = metrics.get("probe/rel_x_mae_units", float("nan"))
+
         if not (np_isnan(p0_x) or np_isnan(p1_x)):
+            mae_suffix = ""
+            if not (np_isnan(p0_x_mae) or np_isnan(p1_x_mae)):
+                mae_suffix = f", MAE P0={p0_x_mae:.1f} P1={p1_x_mae:.1f} game units"
             if p0_x > 0.8 and p1_x > 0.8:
-                lines.append(f"- Per-player x probes: HEALTHY (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f})")
+                lines.append(f"- Per-player x probes: HEALTHY (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f}{mae_suffix})")
             elif abs(p0_x - p1_x) > 0.2:
                 lines.append(
-                    f"- Per-player x probes: ASYMMETRIC (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f}) — "
+                    f"- Per-player x probes: ASYMMETRIC (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f}{mae_suffix}) — "
                     f"one player is decodable, the other is not"
                 )
             else:
-                lines.append(f"- Per-player x probes: WEAK (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f})")
+                lines.append(f"- Per-player x probes: WEAK (P0 R²={p0_x:.3f}, P1 R²={p1_x:.3f}{mae_suffix})")
+
         if not np_isnan(rel_x):
+            mae_suffix = ""
+            if not np_isnan(rel_x_mae):
+                mae_suffix = f", MAE={rel_x_mae:.1f} game units"
             if rel_x > 0.8:
-                lines.append(f"- Relational rel_x probe: HEALTHY (R²={rel_x:.3f}) — cross-player binding present")
+                lines.append(f"- Relational rel_x probe: HEALTHY (R²={rel_x:.3f}{mae_suffix}) — cross-player binding present")
             else:
-                lines.append(f"- Relational rel_x probe: WEAK (R²={rel_x:.3f}) — cross-player binding missing")
+                lines.append(f"- Relational rel_x probe: WEAK (R²={rel_x:.3f}{mae_suffix}) — cross-player binding missing")
+
+    # Action classification probes (400 classes → random = 0.25%)
+    p0_action_acc = metrics.get("probe/p0_action_acc", float("nan"))
+    p1_action_acc = metrics.get("probe/p1_action_acc", float("nan"))
+    if not (np_isnan(p0_action_acc) and np_isnan(p1_action_acc)):
+        # Healthy is well above random (~0.25%); "very healthy" above 20%
+        asym = abs(p0_action_acc - p1_action_acc) > 0.1
+        if p0_action_acc > 0.2 and p1_action_acc > 0.2 and not asym:
+            tag = "HEALTHY"
+        elif asym:
+            tag = "ASYMMETRIC"
+        elif p0_action_acc > 0.05 and p1_action_acc > 0.05:
+            tag = "WEAK"
+        else:
+            tag = "NEAR-RANDOM"
+        lines.append(
+            f"- Action classification: {tag} (P0 acc={p0_action_acc:.3f}, "
+            f"P1 acc={p1_action_acc:.3f}; random ≈ 0.003)"
+        )
 
     straight = metrics.get("emergent/straightness", float("nan"))
     if not np_isnan(straight):

--- a/training/jepa_diagnostics.py
+++ b/training/jepa_diagnostics.py
@@ -10,23 +10,29 @@ trunk preserve player identity or collapse to swap-symmetric features?
 See docs/jepa-data-flow.md for the full trace and motivation.
 
 Diagnostics:
-    swap_test              — encoder collapse detector (P0↔P1 swap cosine sim)
-    per_player_probes      — linear decodability of P0/P1 physical quantities
-    relational_probe       — cross-player binding (e.g., P0.x - P1.x)
-    temporal_straightness  — LeWM's emergent diagnostic on latent trajectories
+    swap_test                  — encoder collapse detector (P0↔P1 swap cosine sim)
+    linear_probe_regression    — continuous probe with R² and game-units MAE
+    linear_probe_classification — discrete probe (action_state) with holdout acc
+    run_linear_probes          — per-player + relational + action probes
+    temporal_straightness      — LeWM's emergent diagnostic on latent trajectories
 
 All functions take a JEPAWorldModel (or its encoder) and a batch of
 (float_frames, int_frames, ctrl_inputs). They do not mutate state.
 
 Expected reading:
-    swap_test.mean_cosine_sim:  LOW (< ~0.5) = healthy identity preservation
-                                HIGH (> ~0.9) = identity collapse
-    swap_test.ditto_cosine_sim: sharpest signal — dittos have no character
-                                asymmetry, so position/velocity/action are
-                                the only identity signal
+    swap_test.mean_cosine_sim:   LOW (< ~0.5) = healthy identity preservation
+                                 HIGH (> ~0.9) = identity collapse
+    swap_test.ditto_cosine_sim:  sharpest signal — dittos have no character
+                                 asymmetry, so position/velocity/action are
+                                 the only identity signal
     per_player probes R²:        HIGH (> 0.8) for position, percent = healthy
-                                LOW (< 0.3) = latent doesn't encode basic physics
+                                 LOW (< 0.3) = latent doesn't encode basic physics
+    per_player probes mae_units: MAE in game units (pixels for x/y, pct for
+                                 percent/shield). The run card success
+                                 criteria are written in game-unit terms.
     relational probe R²:         HIGH for (P0.x - P1.x) = cross-player binding OK
+    action probe accuracy:       random = 1/action_vocab (~0.25% on 400 classes);
+                                 healthy is well above random (tens of percent)
     temporal_straightness:       should INCREASE during training per LeWM
 """
 
@@ -202,23 +208,45 @@ def swap_test(
 # ============================================================================
 # Linear probes — decodability of game state from the latent
 # ============================================================================
+#
+# Three probe types:
+#   1. linear_probe_regression — closed-form least squares, returns R² and
+#      MAE in game units (via a per-target scale factor from EncodingConfig).
+#      R² is scale-invariant so the raw fit signal is the same either way,
+#      but MAE-in-game-units is what the run card's success criteria are
+#      written against ("recovers position to <N game units error").
+#   2. linear_probe_classification — ported from the deleted training/jepa_eval.py
+#      (commit 01aaa99). 200 SGD steps on a linear head, returns holdout
+#      accuracy. Used for discrete targets like action_state (400 classes).
+#   3. run_linear_probes — wraps everything, computes per-player + relational +
+#      action probes in a single pass on one batch.
 
-def linear_probe_r2(
+
+def linear_probe_regression(
     embeddings: torch.Tensor,
     targets: torch.Tensor,
     val_frac: float = 0.2,
-) -> float:
+    scale: float = 1.0,
+) -> dict[str, float]:
     """Fit a linear regression from embeddings to targets with a holdout split.
 
-    Pure torch, closed-form least squares — no sklearn dependency.
+    Pure torch, closed-form least squares — no sklearn dependency. Returns
+    both the scale-invariant R² on held-out samples and the MAE denormalized
+    to game units via the `scale` factor.
 
     Args:
         embeddings: (N, D) — flattened latents
-        targets:    (N,)   — continuous target (e.g., P0.x)
-        val_frac:   fraction of samples held out for R² evaluation
+        targets:    (N,)   — continuous target in normalized encoding units
+                             (e.g., `float_frames[..., 1]` for P0.x × 0.05)
+        val_frac:   fraction of samples held out for R²/MAE evaluation
+        scale:      EncodingConfig scale factor (e.g., `cfg.xy_scale = 0.05`).
+                    MAE in game units = MAE_normalized / scale.
+                    Pass 1.0 if the target is already in game units.
 
     Returns:
-        R² score on the validation split (can be negative for very bad fits).
+        dict with:
+            "r2":        R² on the held-out split (can be negative for bad fits)
+            "mae_units": MAE on the held-out split, converted to game units
     """
     if embeddings.ndim != 2:
         raise ValueError(f"embeddings must be 2D, got {embeddings.shape}")
@@ -241,8 +269,8 @@ def linear_probe_r2(
     train_idx = perm[val_n:]
     if train_idx.numel() < D + 1:
         # Not enough training samples for a unique solution — fall back to
-        # a ridge-regularized fit so we still return a finite R².
-        return _ridge_r2(emb, y, train_idx, val_idx, ridge=1e-3)
+        # a ridge-regularized fit so we still return finite metrics.
+        return _ridge_regression(emb, y, train_idx, val_idx, ridge=1e-3, scale=scale)
 
     ones_train = torch.ones(train_idx.numel(), 1, device=device, dtype=dtype)
     ones_val = torch.ones(val_n, 1, device=device, dtype=dtype)
@@ -255,22 +283,20 @@ def linear_probe_r2(
     try:
         w = torch.linalg.lstsq(X_train, y_train.unsqueeze(-1)).solution.squeeze(-1)
     except RuntimeError:
-        return _ridge_r2(emb, y, train_idx, val_idx, ridge=1e-3)
+        return _ridge_regression(emb, y, train_idx, val_idx, ridge=1e-3, scale=scale)
 
     y_pred = X_val @ w
-    ss_res = ((y_val - y_pred) ** 2).sum()
-    ss_tot = ((y_val - y_val.mean()) ** 2).sum().clamp_min(1e-12)
-    r2 = (1.0 - ss_res / ss_tot).item()
-    return r2
+    return _r2_and_mae(y_val, y_pred, scale)
 
 
-def _ridge_r2(
+def _ridge_regression(
     emb: torch.Tensor,
     y: torch.Tensor,
     train_idx: torch.Tensor,
     val_idx: torch.Tensor,
     ridge: float,
-) -> float:
+    scale: float,
+) -> dict[str, float]:
     """Ridge-regularized least squares fallback when samples < features."""
     device = emb.device
     dtype = emb.dtype
@@ -289,9 +315,91 @@ def _ridge_r2(
     b = X_train.T @ y_train
     w = torch.linalg.solve(A, b)
     y_pred = X_val @ w
+    return _r2_and_mae(y_val, y_pred, scale)
+
+
+def _r2_and_mae(
+    y_val: torch.Tensor, y_pred: torch.Tensor, scale: float
+) -> dict[str, float]:
+    """Compute R² (scale-invariant) and MAE in game units from a val split."""
     ss_res = ((y_val - y_pred) ** 2).sum()
     ss_tot = ((y_val - y_val.mean()) ** 2).sum().clamp_min(1e-12)
-    return (1.0 - ss_res / ss_tot).item()
+    r2 = (1.0 - ss_res / ss_tot).item()
+    mae_normalized = (y_val - y_pred).abs().mean().item()
+    # scale is the EncodingConfig multiplier (x_normalized = x_game * scale).
+    # To recover game units: divide normalized by scale.
+    mae_units = mae_normalized / scale if scale > 0 else mae_normalized
+    return {"r2": r2, "mae_units": mae_units}
+
+
+def linear_probe_classification(
+    embeddings: torch.Tensor,
+    targets: torch.Tensor,
+    num_classes: int,
+    val_frac: float = 0.2,
+    lr: float = 0.1,
+    steps: int = 200,
+) -> float:
+    """Fit a linear classifier with internal holdout, return validation accuracy.
+
+    Closed-form multinomial logistic isn't cheap; a few hundred SGD steps on
+    a linear head is enough for a probe — we just need to know whether the
+    signal is linearly decodable. Ported from training/jepa_eval.py (deleted
+    in the PR #22 merge) with the split changed to internal-holdout to match
+    the rest of this module.
+
+    Args:
+        embeddings: (N, D) — flattened latents
+        targets:    (N,)   — long tensor of class indices
+        num_classes: size of the classification head
+        val_frac:   fraction of samples held out for accuracy evaluation
+        lr:         SGD learning rate (matches jepa_eval.py default)
+        steps:      number of SGD steps (matches jepa_eval.py default)
+
+    Returns:
+        Held-out classification accuracy in [0, 1].
+    """
+    if embeddings.ndim != 2:
+        raise ValueError(f"embeddings must be 2D, got {embeddings.shape}")
+    if targets.ndim != 1 or targets.shape[0] != embeddings.shape[0]:
+        raise ValueError(
+            f"targets must be 1D matching embeddings[0]: "
+            f"emb {embeddings.shape}, targets {targets.shape}"
+        )
+
+    N, D = embeddings.shape
+    device = embeddings.device
+
+    val_n = max(1, int(N * val_frac))
+    perm = torch.randperm(N, device=device)
+    val_idx = perm[:val_n]
+    train_idx = perm[val_n:]
+
+    X_tr = embeddings[train_idx].float()
+    y_tr = targets[train_idx].long()
+    X_va = embeddings[val_idx].float()
+    y_va = targets[val_idx].long()
+
+    W = torch.zeros(D, num_classes, device=device, requires_grad=True)
+    bias = torch.zeros(num_classes, device=device, requires_grad=True)
+    optim = torch.optim.SGD([W, bias], lr=lr, momentum=0.9)
+
+    # Training loop needs grads even though this function is called under no_grad;
+    # guard with enable_grad for safety.
+    with torch.enable_grad():
+        for _ in range(steps):
+            logits = X_tr @ W + bias
+            loss = F.cross_entropy(logits, y_tr)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+
+    with torch.no_grad():
+        val_logits = X_va @ W + bias
+        pred = val_logits.argmax(dim=-1)
+        acc = (pred == y_va).float().mean().item()
+
+    return acc
 
 
 def extract_probe_targets(
@@ -303,9 +411,12 @@ def extract_probe_targets(
 
     The float layout per player (from EncodingConfig):
         [percent, x, y, shield, (5 velocity dims), ...]
-
-    So P0.percent is at index 0, P0.x at 1, P0.y at 2, etc.
+    So P0.percent is at index 0, P0.x at 1, P0.y at 2, shield at 3.
     P1 is offset by float_per_player.
+
+    The int layout per player (from EncodingConfig):
+        [action, jumps, character, l_cancel, hurtbox, ground, last_attack, (state_age)]
+    So P0.action is at int index 0, P1.action at int index int_per_player.
 
     Args:
         float_frames: (B, T, 2*fp)
@@ -313,13 +424,15 @@ def extract_probe_targets(
         cfg:          EncodingConfig
 
     Returns:
-        Flat dict of named (B*T,) tensors ready for linear_probe_r2.
+        Flat dict of named (B*T,) tensors. Continuous targets are normalized
+        (use `_probe_scale(name, cfg)` to convert MAE to game units).
+        Categorical targets are long tensors.
     """
     fp = cfg.float_per_player
     ipp = cfg.int_per_player
 
-    # Core continuous layout: percent=0, x=1, y=2, shield=3
     targets = {
+        # Continuous, normalized (scale via _probe_scale)
         "p0_percent": float_frames[..., 0].flatten(),
         "p0_x": float_frames[..., 1].flatten(),
         "p0_y": float_frames[..., 2].flatten(),
@@ -328,25 +441,52 @@ def extract_probe_targets(
         "p1_x": float_frames[..., fp + 1].flatten(),
         "p1_y": float_frames[..., fp + 2].flatten(),
         "p1_shield": float_frames[..., fp + 3].flatten(),
-        # Relational targets — require cross-player binding in the latent
+        # Relational — require cross-player binding in the latent
         "rel_x": (float_frames[..., 1] - float_frames[..., fp + 1]).flatten(),
         "rel_y": (float_frames[..., 2] - float_frames[..., fp + 2]).flatten(),
         "rel_percent": (float_frames[..., 0] - float_frames[..., fp + 0]).flatten(),
+        # Categorical — long tensors for classification probes
+        "p0_action": int_frames[..., 0].flatten().long(),
+        "p1_action": int_frames[..., ipp].flatten().long(),
     }
     return targets
 
 
+def _probe_scale(name: str, cfg: EncodingConfig) -> float:
+    """Map a continuous probe target name to its EncodingConfig scale factor.
+
+    The scale factor is the multiplier that takes game units → normalized
+    encoding (e.g., `x_normalized = x_game * cfg.xy_scale`), so dividing a
+    normalized MAE by the scale recovers game-unit error. Targets absent
+    from this map get scale=1.0 (returned MAE stays in normalized units).
+    """
+    if name in ("p0_x", "p0_y", "p1_x", "p1_y", "rel_x", "rel_y"):
+        return cfg.xy_scale
+    if name in ("p0_percent", "p1_percent", "rel_percent"):
+        return cfg.percent_scale
+    if name in ("p0_shield", "p1_shield"):
+        return cfg.shield_scale
+    return 1.0
+
+
 @dataclass
 class ProbeResults:
-    per_player: dict[str, float]
-    relational: dict[str, float]
+    # Continuous probes: each value is {"r2": float, "mae_units": float}
+    per_player: dict[str, dict[str, float]]
+    relational: dict[str, dict[str, float]]
+    # Classification probes: each value is accuracy in [0, 1]
+    action: dict[str, float]
 
     def to_dict(self) -> dict[str, float]:
-        out = {}
+        out: dict[str, float] = {}
         for k, v in self.per_player.items():
-            out[f"probe/{k}_r2"] = v
+            out[f"probe/{k}_r2"] = v["r2"]
+            out[f"probe/{k}_mae_units"] = v["mae_units"]
         for k, v in self.relational.items():
-            out[f"probe/{k}_r2"] = v
+            out[f"probe/{k}_r2"] = v["r2"]
+            out[f"probe/{k}_mae_units"] = v["mae_units"]
+        for k, v in self.action.items():
+            out[f"probe/{k}_acc"] = v
         return out
 
 
@@ -358,30 +498,37 @@ def run_linear_probes(
     cfg: EncodingConfig,
     val_frac: float = 0.2,
 ) -> ProbeResults:
-    """Encode the batch and fit linear probes for per-player and relational targets.
+    """Encode the batch and fit all linear probes.
 
-    Per-player probes (separate P0 and P1):
-        percent, x, y, shield
+    Per-player continuous probes (regression):
+        p0_percent, p0_x, p0_y, p0_shield, p1_percent, p1_x, p1_y, p1_shield
+        Each returns R² and MAE in game units.
 
-    Relational probes (cross-player binding):
-        rel_x   = P0.x - P1.x
-        rel_y   = P0.y - P1.y
+    Relational continuous probes (regression):
+        rel_x = P0.x - P1.x
+        rel_y = P0.y - P1.y
         rel_percent = P0.percent - P1.percent
+        Test cross-player binding — a latent that just stacks independent
+        per-player slots can't fit these well.
 
-    A healthy representation fits all per-player probes with high R² (> 0.8
-    expected for positions and percent, which are directly encoded inputs).
-    Relational probes test whether the latent encodes cross-player structure
-    rather than just stacking independent per-player slots.
+    Action classification probes:
+        p0_action, p1_action — 400-class linear classification, holdout accuracy.
+
+    Healthy fit (expected on a working representation):
+        - per-player r2 > 0.8, mae_units small (e.g., x mae_units < ~10 pixels)
+        - relational r2 > 0.8
+        - action accuracy > random (random = 1/400 = 0.25%); good ≳ 20-40%
+          depending on how much the first frame determines action_state.
 
     Args:
         encoder:      GameStateEncoder in eval mode
         float_frames: (B, T, F)
         int_frames:   (B, T, I)
-        cfg:          EncodingConfig
-        val_frac:     fraction held out for R²
+        cfg:          EncodingConfig (for slot sizing and probe scales)
+        val_frac:     fraction held out within the batch
 
     Returns:
-        ProbeResults with per_player and relational R² dicts.
+        ProbeResults dataclass with per_player, relational, and action dicts.
     """
     assert not encoder.training, "run_linear_probes requires encoder.eval()"
 
@@ -390,16 +537,33 @@ def run_linear_probes(
 
     targets = extract_probe_targets(float_frames, int_frames, cfg)
 
-    per_player_keys = ["p0_percent", "p0_x", "p0_y", "p0_shield",
-                       "p1_percent", "p1_x", "p1_y", "p1_shield"]
+    per_player_keys = [
+        "p0_percent", "p0_x", "p0_y", "p0_shield",
+        "p1_percent", "p1_x", "p1_y", "p1_shield",
+    ]
     relational_keys = ["rel_x", "rel_y", "rel_percent"]
+    action_keys = ["p0_action", "p1_action"]
 
-    per_player = {k: linear_probe_r2(flat_embs, targets[k], val_frac)
-                  for k in per_player_keys}
-    relational = {k: linear_probe_r2(flat_embs, targets[k], val_frac)
-                  for k in relational_keys}
+    per_player = {
+        k: linear_probe_regression(
+            flat_embs, targets[k], val_frac, scale=_probe_scale(k, cfg),
+        )
+        for k in per_player_keys
+    }
+    relational = {
+        k: linear_probe_regression(
+            flat_embs, targets[k], val_frac, scale=_probe_scale(k, cfg),
+        )
+        for k in relational_keys
+    }
+    action = {
+        k: linear_probe_classification(
+            flat_embs, targets[k], num_classes=cfg.action_vocab, val_frac=val_frac,
+        )
+        for k in action_keys
+    }
 
-    return ProbeResults(per_player=per_player, relational=relational)
+    return ProbeResults(per_player=per_player, relational=relational, action=action)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Pre-launch review of e030a found three real docs-vs-code mismatches from the PR #22 merge (where `training/jepa_eval.py` was deleted in favor of `jepa_diagnostics.py` but some capabilities didn't make the translation), one yaml/run-card policy drift, and several cosmetic staleness issues. All fixes landed here. **Pure additions to `jepa_diagnostics.py` plus docs — zero changes to in-flight files** (`jepa_trainer.py`, `modal_train_jepa.py`, `models/jepa/*.py`, `data/jepa_dataset.py`).

### Verdict before fixes

Not launchable as-is — not because anything was broken, but because the run card was committing to evaluation signals the shipped code couldn't produce. Launching would have generated wandb metrics that don't match the run card.

## Three real gaps closed

### 1. Action-state classification probe was lost in the PR #22 merge

Run card listed `action_state` accuracy as a primary per-epoch signal but `jepa_diagnostics.py` had no classification probe. **Ported `linear_probe_classification` back** from commit `01aaa99`'s `jepa_eval.py` — 200 SGD steps, 400-class holdout accuracy, same defaults (`lr=0.1`, `momentum=0.9`). Adapted to the in-batch holdout pattern of the rest of the module. Emits `probe/p0_action_acc` and `probe/p1_action_acc`.

### 2. Game-units MAE was lost in the PR #22 merge

Old `linear_probe_regression` returned `{r2, mae}` with MAE denormalized via `cfg.xy_scale` / `cfg.percent_scale`. New `linear_probe_r2` returned R² only. Run card Success Criteria was written in game-unit terms (\"recovers position to <N game units error\") — couldn't check the criterion.

**Renamed `linear_probe_r2` → `linear_probe_regression`**, now takes a `scale` parameter and returns `{\"r2\", \"mae_units\"}`. Added `_probe_scale(name, cfg)` helper mapping target names to `EncodingConfig` scale factors (`xy_scale`, `percent_scale`, `shield_scale`). `ProbeResults` emits both `probe/X_r2` and `probe/X_mae_units`. R² keys preserved so existing dashboards/parsers don't break.

### 3. RC@5/RC@10 is not computed for JEPA

The K=5/K=10 infrastructure landed in `scripts/eval_rollout.py` and Mamba2's `training/trainer.py::_rollout_eval`, but that path requires the per-field prediction heads JEPA doesn't have. `JEPATrainer` never calls `_rollout_eval`, and there's no JEPA equivalent. The run card listed RC@5/@10 as the **first** primary signal — a signal nothing produces.

**Updated run card to explicitly defer RC for e030a.** Primary quantitative signal is now the linear probe suite (continuous R² + game-units MAE, action classification accuracy, identity diagnostics). RC comparison against Mamba2 is promoted to e030b or e030c once a decoder pattern is chosen:

- **Probe-as-decoder** — roll out latents K steps, decode each through the current epoch's fitted linear probe weights. Cheap, but mixes probe error with rollout error.
- **Separately-trained decoder head** — pure, but another training step.

Both are real design decisions worth their own experiment; neither is the right thing to bolt onto the e030a baseline. **Project-wide K=5/K=10 RC work still stands for the Mamba2 line** — it's just not e030a's north star.

## yaml/run-card policy reconciliation

- `experiments/e030a-jepa-baseline.yaml`: `num_epochs: 100` → `num_epochs: 50` (matches run card \"Up to 50 epochs, instrument don't cap\" policy). Header comment `e028a:` → `e030a:`. LR/WD lines tagged \"probable lever\" inline so any future CLI overrides have context.

## Run card cleanup

- **Context table**: Mamba2 best RC corrected from b002's stale 4.965 to e028a-full-stack's 4.798 (frontmatter `prior_best_rc` was already right).
- **\"Known blocking fixes (pre-Modal)\" → \"Resolved blocking fixes (landed in commit 01aaa99)\"** with ✅ markers and `file:line` references for each fix.
- **References section expanded** to include `scripts/modal_train_jepa.py`, `training/jepa_diagnostics.py`, `docs/jepa-data-flow.md`, `scripts/run_jepa_diagnostics.py`.
- **Success Criteria rewritten in probe terms** — every threshold (Promising / Competitive / Not viable / Identity-collapsed / Too early) now references a metric the code actually computes. Specific thresholds for R², MAE units, action accuracy, and swap similarity.

## CLI updates

`scripts/run_jepa_diagnostics.py` interpretation section now:
- Surfaces per-player probe MAE in game units alongside R²
- Adds an Action classification row with `HEALTHY` / `ASYMMETRIC` / `WEAK` / `NEAR-RANDOM` tags

## Test plan

- [x] Smoke test via `python -m scripts.run_jepa_diagnostics --smoke --batch-size 64` — new `probe/*_mae_units` and `probe/*_action_acc` keys appear in output, CLI interpretation shows them cleanly, no crashes. Random-model numbers are garbage (expected); shape is right.
- [x] Grep for stale references: all remaining `e028a` mentions are intentional lineage/history notes. No stale RC@5/@10 promises, no stale 100-epoch, no stale 4.965, no references to the deleted `linear_probe_r2` or `jepa_eval`.
- [ ] End-to-end validation on a real JEPA checkpoint once e030a produces `checkpoints/e030a-jepa-baseline/best.pt`.

## Not in this PR (follow-ups)

- **Embedding stats (SVD `rank_frac`)** from old `jepa_eval.py`. SIGReg sanity check — `mean_abs`, `std`, `rank_frac`. Not a blocker since swap test catches the most important failure mode, but worth porting back. ~30 LOC.
- **Longer-trajectory temporal straightness.** Current impl runs on T=4 sequences which gives only 2 consecutive velocity pairs per sample — weak signal. Fix is either add a separate helper that pulls longer subsequences from the val dataset, or run straightness on rolled-out latent trajectories. Flagged in the run card Evaluation section.
- **RC-for-JEPA decoder pattern.** Probe-as-decoder or trained decoder head — design question for e030b or e030c.
- **Mamba2 identity sweep.** Still deferred per Mattie's ask — don't fill context with Mamba2 until after JEPA launches.

## Scope safety

Zero edits to `models/jepa/*.py`, `data/jepa_dataset.py`, `training/jepa_trainer.py`, `scripts/modal_train_jepa.py`. Only touches `training/jepa_diagnostics.py` (pure additions + refactor of probe return type), `scripts/run_jepa_diagnostics.py` (interpretation section), `experiments/e030a-jepa-baseline.yaml` (2 value fixes + header comment), `docs/run-cards/e030a-jepa-baseline.md`, and `docs/HANDOFF.md`.

## What's good to go after this

With this PR merged, e030a is launch-ready:

- Run card and shipped code are internally consistent — every primary signal listed is actually computed and logged.
- yaml and run card agree on the 50-epoch policy.
- Stale references fixed.
- Action classification probe + game-units MAE back in the diagnostic suite.
- Success Criteria expressed in metrics the code produces.

Launch command (unchanged):

\`\`\`bash
modal run --detach scripts/modal_train_jepa.py \\
    --config experiments/e030a-jepa-baseline.yaml \\
    --encoded-file /encoded-e012-fd-top5.pt \\
    --gpu A100 \\
    --run-name e030a-jepa-baseline
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)